### PR TITLE
Remove duplicate Tk root launch

### DIFF
--- a/3dbinx6 21.05.25.py
+++ b/3dbinx6 21.05.25.py
@@ -1405,11 +1405,6 @@ class TabPallet(ttk.Frame):
         ax_3d.set_zlabel('H (mm)')
         canvas_3d.draw()
 
-root = tk.Tk()
-root.title("Paletyzacja")
-app = TabPallet(root)
-root.mainloop()
-
 class MainApp(tk.Tk):
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
## Summary
- drop redundant `TabPallet` Tk instance
- keep `MainApp` as the only entry point

## Testing
- `python -m py_compile '3dbinx6 21.05.25.py'`

------
https://chatgpt.com/codex/tasks/task_e_684025b7cc0483258e339b40f2cc23f1