### PR TITLE
Load carton and pallet data from XML

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -1,0 +1,49 @@
+import os
+import xml.etree.ElementTree as ET
+from functools import lru_cache
+
+DATA_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'data')
+
+
+def _load_xml(path: str) -> ET.Element:
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"Brak pliku: {path}")
+    try:
+        tree = ET.parse(path)
+        return tree.getroot()
+    except ET.ParseError as e:
+        raise ValueError(f"Niepoprawny format XML w pliku {path}: {e}")
+
+
+@lru_cache(maxsize=None)
+def load_cartons() -> dict:
+    """Zwraca słownik kartonów {kod: (w, l, h)}."""
+    root = _load_xml(os.path.join(DATA_DIR, 'cartons.xml'))
+    cartons = {}
+    for carton in root.findall('carton'):
+        try:
+            code = carton.get('code')
+            w = int(carton.get('w'))
+            l = int(carton.get('l'))
+            h = int(carton.get('h'))
+            cartons[code] = (w, l, h)
+        except (TypeError, ValueError) as e:
+            raise ValueError(f"Niepoprawne dane kartonu '{carton.attrib}': {e}")
+    return cartons
+
+
+@lru_cache(maxsize=None)
+def load_pallets() -> list:
+    """Zwraca listę palet w formacie [{'name':.., 'w':.., 'l':.., 'h':..}]"""
+    root = _load_xml(os.path.join(DATA_DIR, 'pallets.xml'))
+    pallets = []
+    for pallet in root.findall('pallet'):
+        try:
+            name = pallet.get('name')
+            w = int(pallet.get('w'))
+            l = int(pallet.get('l'))
+            h = int(pallet.get('h'))
+            pallets.append({'name': name, 'w': w, 'l': l, 'h': h})
+        except (TypeError, ValueError) as e:
+            raise ValueError(f"Niepoprawne dane palety '{pallet.attrib}': {e}")
+    return pallets

--- a/data/cartons.xml
+++ b/data/cartons.xml
@@ -1,0 +1,34 @@
+<cartons>
+  <carton code="O0024" w="360" l="260" h="90"/>
+  <carton code="O0121" w="445" l="254" h="268"/>
+  <carton code="O0122" w="445" l="304" h="268"/>
+  <carton code="O0148" w="365" l="230" h="140"/>
+  <carton code="O0301" w="166" l="112" h="98"/>
+  <carton code="O0632" w="160" l="320" h="115"/>
+  <carton code="O0658" w="285" l="230" h="110"/>
+  <carton code="O0680" w="546" l="392" h="144"/>
+  <carton code="O0718" w="270" l="110" h="105"/>
+  <carton code="O0820" w="341" l="284" h="136"/>
+  <carton code="O1370" w="317" l="207" h="105"/>
+  <carton code="O1434" w="420" l="302" h="153"/>
+  <carton code="O1460" w="270" l="165" h="130"/>
+  <carton code="O1504" w="393" l="288" h="151"/>
+  <carton code="O2314" w="193" l="193" h="155"/>
+  <carton code="O2315" w="355" l="284" h="196"/>
+  <carton code="O2409" w="255" l="170" h="165"/>
+  <carton code="O2830" w="285" l="240" h="145"/>
+  <carton code="O2829" w="285" l="240" h="100"/>
+  <carton code="O2902" w="252" l="168" h="94"/>
+  <carton code="O3290" w="315" l="257" h="170"/>
+  <carton code="O3467" w="426" l="252" h="160"/>
+  <carton code="O3698" w="284" l="215" h="118"/>
+  <carton code="O3769" w="395" l="348" h="97"/>
+  <carton code="O3815" w="380" l="270" h="132"/>
+  <carton code="O3874" w="566" l="356" h="124"/>
+  <carton code="O3927" w="228" l="153" h="135"/>
+  <carton code="O3928" w="705" l="288" h="135"/>
+  <carton code="O3929" w="192" l="95" h="87"/>
+  <carton code="O3930" w="374" l="235" h="87"/>
+  <carton code="O3961" w="158" l="107" h="110"/>
+  <carton code="O3962" w="364" l="244" h="115"/>
+</cartons>

--- a/data/pallets.xml
+++ b/data/pallets.xml
@@ -1,0 +1,6 @@
+<pallets>
+  <pallet name="EUR1" w="1200" l="800" h="1600"/>
+  <pallet name="EUR2" w="1200" l="1000" h="1600"/>
+  <pallet name="EUR3" w="1000" l="600" h="1600"/>
+  <pallet name="Half" w="800" l="600" h="1600"/>
+</pallets>


### PR DESCRIPTION
## Summary
- move carton and pallet sizes into XML files
- add helper utilities to load the XML data lazily
- update the main application to read cartons and pallets via the new helpers

## Testing
- `python -m py_compile '3dbinx6 21.05.25.py' core/utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68409aa4cea08325813c0a3533bc7fbc