### PR TITLE
Enable auto-update of product fields

### DIFF
--- a/packing_app/gui/tab_2d.py
+++ b/packing_app/gui/tab_2d.py
@@ -79,6 +79,7 @@ class TabPacking2D(ttk.Frame):
         f_type.pack(side=tk.TOP, fill=tk.X, padx=5, pady=2)
 
         self.prod_type = tk.StringVar(value="rectangle")
+        self.prod_type.trace_add("write", lambda *args: self.update_product_fields())
         self.rb_rect = ttk.Radiobutton(f_type, text="Kartoniki", variable=self.prod_type, value="rectangle", command=self.update_product_fields, style="Selected.TRadiobutton")
         self.rb_rect.pack(side=tk.LEFT, padx=5)
         self.rb_circle = ttk.Radiobutton(f_type, text="Pojemniki/Butelki", variable=self.prod_type, value="circle", command=self.update_product_fields, style="Unselected.TRadiobutton")


### PR DESCRIPTION
## Summary
- trigger `update_product_fields` whenever product type changes

## Testing
- `python -m py_compile packing_app/gui/tab_2d.py`
- `python -m py_compile main.py packing_app/gui/tab_3d.py packing_app/gui/tab_pallet.py`
- *Unable to run GUI tests: `tkinter` requires a display.*

------
https://chatgpt.com/codex/tasks/task_e_6840abe43edc83259f7072152fa61227