### PR TITLE
Add pallet height setting and auto layer calc

### DIFF
--- a/data/pallets.xml
+++ b/data/pallets.xml
@@ -1,6 +1,6 @@
 <pallets>
-  <pallet name="EUR1" w="1200" l="800" h="1600"/>
-  <pallet name="EUR2" w="1200" l="1000" h="1600"/>
-  <pallet name="EUR3" w="1000" l="600" h="1600"/>
-  <pallet name="Half" w="800" l="600" h="1600"/>
+  <pallet name="EUR1" w="1200" l="800" h="144"/>
+  <pallet name="EUR2" w="1200" l="1000" h="144"/>
+  <pallet name="EUR3" w="1000" l="600" h="144"/>
+  <pallet name="Half" w="800" l="600" h="144"/>
 </pallets>


### PR DESCRIPTION
## Summary
- normalize pallet height data to 144 mm
- allow specifying maximum stack height on the pallet
- compute allowed layers automatically and show totals

## Testing
- `python -m py_compile $(git ls-files '*.py' -z | xargs -0)`

------
https://chatgpt.com/codex/tasks/task_e_6840abeeaa388325a268bae70c5530db