### PR TITLE
Fix alternate transformations with empty transform_vars

### DIFF
--- a/3dbinx6 21.05.25.py
+++ b/3dbinx6 21.05.25.py
@@ -1240,7 +1240,7 @@ class TabPallet(ttk.Frame):
 
     def update_transformations(self, *args):
         self.transformations = [var.get() for var in self.transform_vars]
-        if self.alternate_var.get():
+        if self.alternate_var.get() and len(self.transform_vars) > 1:
             for i in range(len(self.transformations)):
                 self.transformations[i] = self.transform_vars[1].get() if i % 2 else "Brak"
         self.draw_pallet()

--- a/packing_app/gui/tab_pallet.py
+++ b/packing_app/gui/tab_pallet.py
@@ -219,7 +219,7 @@ class TabPallet(ttk.Frame):
 
     def update_transformations(self, *args):
         self.transformations = [var.get() for var in self.transform_vars]
-        if self.alternate_var.get():
+        if self.alternate_var.get() and len(self.transform_vars) > 1:
             for i in range(len(self.transformations)):
                 self.transformations[i] = self.transform_vars[1].get() if i % 2 else "Brak"
         self.draw_pallet()


### PR DESCRIPTION
## Summary
- guard against missing transformation options when updating layers

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840bbf4680c8325b74bd06e45dcbd2d