### PR TITLE
Add materials tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ Launch the interface by executing:
 ```bash
 python main.py
 ```
-The window opens with three tabs:
+The window opens with four tabs:
 
 1. **Pakowanie 2D** – compare layouts of small boxes or bottles inside a chosen carton. Select a predefined carton or fill in your own dimensions. The tab shows vertical, horizontal and mixed layouts and lets you add air cushions.
 2. **Pakowanie 3D** – find good carton sizes for a given product using a random search and the list of predefined cartons.
 3. **Paletyzacja** – plan layers of cartons on a pallet. Choose a pallet type and a carton type from drop‑downs, adjust dimensions and transformations and preview the stacking in 2D or 3D.
+4. **Materiały** – manage a simple list of packaging materials stored in `data/packaging_materials.xml`.
 
 Predefined cartons and pallets come from the data files and can be selected from the drop‑down menus on each tab.

--- a/core/utils.py
+++ b/core/utils.py
@@ -62,3 +62,34 @@ def load_materials() -> dict:
         except (TypeError, ValueError) as e:
             raise ValueError(f"Niepoprawne dane materiału '{mat.attrib}': {e}")
     return materials
+
+
+def load_packaging_materials() -> list:
+    """Load packaging materials from packaging_materials.xml."""
+    path = os.path.join(DATA_DIR, 'packaging_materials.xml')
+    if not os.path.exists(path):
+        return []
+    root = _load_xml(path)
+    materials = []
+    for mat in root.findall('material'):
+        materials.append({
+            'name': mat.get('name', ''),
+            'quantity': mat.get('quantity', ''),
+            'comment': mat.get('comment', '')
+        })
+    return materials
+
+
+def save_packaging_materials(materials: list) -> None:
+    """Save packaging materials to packaging_materials.xml."""
+    root = ET.Element('materials')
+    for mat in materials:
+        ET.SubElement(
+            root,
+            'material',
+            name=mat.get('name', ''),
+            quantity=mat.get('quantity', ''),
+            comment=mat.get('comment', '')
+        )
+    tree = ET.ElementTree(root)
+    tree.write(os.path.join(DATA_DIR, 'packaging_materials.xml'), encoding='utf-8', xml_declaration=True)

--- a/data/packaging_materials.xml
+++ b/data/packaging_materials.xml
@@ -1,0 +1,2 @@
+<materials>
+</materials>

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ from tkinter import ttk
 from packing_app.gui.tab_2d import TabPacking2D
 from packing_app.gui.tab_3d import TabBox3D
 from packing_app.gui.tab_pallet import TabPallet
+from packing_app.gui.tab_materials import TabMaterials
 
 
 def main():
@@ -17,11 +18,13 @@ def main():
     tab1 = TabPacking2D(notebook)
     tab2 = TabBox3D(notebook)
     tab3 = TabPallet(notebook)
+    tab4 = TabMaterials(notebook)
     tab1.set_pallet_tab(tab3)
 
     notebook.add(tab1, text="Pakowanie 2D")
     notebook.add(tab2, text="Pakowanie 3D")
     notebook.add(tab3, text="Paletyzacja")
+    notebook.add(tab4, text="Materiały")
 
     root.mainloop()
 

--- a/packing_app/gui/tab_materials.py
+++ b/packing_app/gui/tab_materials.py
@@ -1,0 +1,89 @@
+import tkinter as tk
+from tkinter import ttk, messagebox
+
+from core.utils import load_packaging_materials, save_packaging_materials
+
+
+class TabMaterials(ttk.Frame):
+    def __init__(self, parent):
+        super().__init__(parent)
+        self.materials = load_packaging_materials()
+        self.selected_index = None
+        self.build_ui()
+
+    def build_ui(self):
+        list_frame = ttk.Frame(self)
+        list_frame.pack(side=tk.LEFT, fill=tk.BOTH, expand=True, padx=5, pady=5)
+
+        self.listbox = tk.Listbox(list_frame, height=15)
+        self.listbox.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        self.listbox.bind("<<ListboxSelect>>", self.on_select)
+
+        scrollbar = ttk.Scrollbar(list_frame, orient="vertical", command=self.listbox.yview)
+        scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
+        self.listbox.config(yscrollcommand=scrollbar.set)
+
+        form = ttk.Frame(self)
+        form.pack(side=tk.LEFT, fill=tk.Y, padx=10, pady=5)
+
+        ttk.Label(form, text="Nazwa:").grid(row=0, column=0, sticky="e", pady=2)
+        self.name_var = tk.StringVar()
+        ttk.Entry(form, textvariable=self.name_var, width=25).grid(row=0, column=1, pady=2)
+
+        ttk.Label(form, text="Ilość/Jednostka:").grid(row=1, column=0, sticky="e", pady=2)
+        self.qty_var = tk.StringVar()
+        ttk.Entry(form, textvariable=self.qty_var, width=25).grid(row=1, column=1, pady=2)
+
+        ttk.Label(form, text="Komentarz:").grid(row=2, column=0, sticky="e", pady=2)
+        self.comment_var = tk.StringVar()
+        ttk.Entry(form, textvariable=self.comment_var, width=25).grid(row=2, column=1, pady=2)
+
+        btn_frame = ttk.Frame(form)
+        btn_frame.grid(row=3, column=0, columnspan=2, pady=5)
+        ttk.Button(btn_frame, text="Dodaj / Aktualizuj", command=self.add_update).pack(side=tk.LEFT, padx=2)
+        ttk.Button(btn_frame, text="Usuń", command=self.delete_item).pack(side=tk.LEFT, padx=2)
+        ttk.Button(btn_frame, text="Zapisz", command=self.save).pack(side=tk.LEFT, padx=2)
+
+        self.refresh_list()
+
+    def refresh_list(self):
+        self.listbox.delete(0, tk.END)
+        for mat in self.materials:
+            self.listbox.insert(tk.END, mat.get("name", ""))
+
+    def on_select(self, event):
+        if not self.listbox.curselection():
+            self.selected_index = None
+            return
+        idx = self.listbox.curselection()[0]
+        self.selected_index = idx
+        mat = self.materials[idx]
+        self.name_var.set(mat.get("name", ""))
+        self.qty_var.set(mat.get("quantity", ""))
+        self.comment_var.set(mat.get("comment", ""))
+
+    def add_update(self):
+        data = {
+            "name": self.name_var.get(),
+            "quantity": self.qty_var.get(),
+            "comment": self.comment_var.get(),
+        }
+        if self.selected_index is None:
+            self.materials.append(data)
+        else:
+            self.materials[self.selected_index] = data
+        self.refresh_list()
+
+    def delete_item(self):
+        if self.selected_index is not None:
+            del self.materials[self.selected_index]
+            self.selected_index = None
+            self.refresh_list()
+
+    def save(self):
+        try:
+            save_packaging_materials(self.materials)
+            messagebox.showinfo("Zapis", "Zapisano dane do pliku.")
+        except Exception as e:
+            messagebox.showerror("Błąd", str(e))
+


### PR DESCRIPTION
## Summary
- add new `packaging_materials.xml` file
- implement `load_packaging_materials` and `save_packaging_materials`
- add materials management GUI tab
- update notebook setup to show new tab
- document new tab in README

## Testing
- `find . -name '*.py' -print0 | xargs -0 python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_6840bf288948832589b4ec44d1802df1