### PR TITLE
Add interlocked layout option

### DIFF
--- a/interlock_demo.py
+++ b/interlock_demo.py
@@ -1,38 +1,7 @@
 import matplotlib.pyplot as plt
 from matplotlib.patches import Rectangle
 
-from packing_app.core.algorithms import pack_rectangles_mixed_greedy
-
-
-def compute_interlocked_layout(pallet_w, pallet_l, box_w, box_l, num_layers=4):
-    """Return positions for standard and interlocked stacking."""
-    count, base_positions = pack_rectangles_mixed_greedy(pallet_w, pallet_l, box_w, box_l)
-
-    # base layout repeated for each layer
-    base_layers = [base_positions for _ in range(num_layers)]
-
-    # determine possible shift (half box size) without leaving pallet bounds
-    min_x = min(x for x, y, w, h in base_positions)
-    max_x = max(x + w for x, y, w, h in base_positions)
-    min_y = min(y for x, y, w, h in base_positions)
-    max_y = max(y + h for x, y, w, h in base_positions)
-
-    shift_x = 0.0
-    shift_y = 0.0
-    if min_x >= box_w / 2 and max_x + box_w / 2 <= pallet_w:
-        shift_x = box_w / 2
-    elif min_y >= box_l / 2 and max_y + box_l / 2 <= pallet_l:
-        shift_y = box_l / 2
-
-    interlocked_layers = []
-    for layer_idx in range(num_layers):
-        if layer_idx % 2 == 0:
-            interlocked_layers.append(base_positions)
-        else:
-            shifted = [(x + shift_x, y + shift_y, w, h) for x, y, w, h in base_positions]
-            interlocked_layers.append(shifted)
-
-    return count, base_layers, interlocked_layers
+from packing_app.core.algorithms import compute_interlocked_layout
 
 
 def plot_layers(ax, layers, pallet_w, pallet_l, title):

--- a/packing_app/core/algorithms.py
+++ b/packing_app/core/algorithms.py
@@ -67,6 +67,34 @@ def pack_rectangles_mixed_greedy(width, height, wprod, lprod, margin=0):
             best_positions = temp_positions
     return best_count, best_positions
 
+def compute_interlocked_layout(pallet_w, pallet_l, box_w, box_l, num_layers=4):
+    """Return positions for standard and interlocked stacking."""
+    count, base_positions = pack_rectangles_mixed_greedy(pallet_w, pallet_l, box_w, box_l)
+
+    base_layers = [base_positions for _ in range(num_layers)]
+
+    min_x = min(x for x, y, w, h in base_positions)
+    max_x = max(x + w for x, y, w, h in base_positions)
+    min_y = min(y for x, y, w, h in base_positions)
+    max_y = max(y + h for x, y, w, h in base_positions)
+
+    shift_x = 0.0
+    shift_y = 0.0
+    if min_x >= box_w / 2 and max_x + box_w / 2 <= pallet_w:
+        shift_x = box_w / 2
+    elif min_y >= box_l / 2 and max_y + box_l / 2 <= pallet_l:
+        shift_y = box_l / 2
+
+    interlocked_layers = []
+    for layer_idx in range(num_layers):
+        if layer_idx % 2 == 0:
+            interlocked_layers.append(base_positions)
+        else:
+            shifted = [(x + shift_x, y + shift_y, w, h) for x, y, w, h in base_positions]
+            interlocked_layers.append(shifted)
+
+    return count, base_layers, interlocked_layers
+
 def pack_rectangles_mixed_max(width, height, wprod, lprod, margin=0):
     eff_width = width - margin
     eff_height = height - margin

--- a/packing_app/gui/tab_pallet.py
+++ b/packing_app/gui/tab_pallet.py
@@ -4,7 +4,7 @@ import matplotlib
 matplotlib.use("TkAgg")
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
-from packing_app.core.algorithms import pack_rectangles_mixed_greedy
+from packing_app.core.algorithms import pack_rectangles_mixed_greedy, compute_interlocked_layout
 from core.utils import load_cartons, load_pallets
 
 
@@ -341,6 +341,10 @@ class TabPallet(ttk.Frame):
         count2, positions2 = pack_rectangles_mixed_greedy(pallet_w, pallet_l, box_l, box_w)
         positions2 = self.center_layout(positions2, pallet_w, pallet_l)
         self.layouts.append((count2, positions2, "Naprzemienny"))
+
+        _, _, interlocked_layers = compute_interlocked_layout(pallet_w, pallet_l, box_w, box_l, num_layers=2)
+        shifted = self.center_layout(interlocked_layers[1], pallet_w, pallet_l)
+        self.layouts.append((len(shifted), shifted, "Przesunięty"))
 
         self.layout_map = {name: idx for idx, (_, __, name) in enumerate(self.layouts)}
         self.update_transform_frame()


### PR DESCRIPTION
## Summary
- move `compute_interlocked_layout` into the algorithms module
- use the interlocked layout in the pallet tab
- update demo to import the new function

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684134694238832598774eac4e60a45e