### PR TITLE
Add carton editing tab

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -95,3 +95,26 @@ def save_packaging_materials(materials: list) -> None:
         )
     tree = ET.ElementTree(root)
     tree.write(os.path.join(DATA_DIR, 'packaging_materials.xml'), encoding='utf-8', xml_declaration=True)
+
+
+def save_cartons(cartons: list) -> None:
+    """Save carton definitions to cartons.xml.
+
+    Parameters
+    ----------
+    cartons: list of dicts
+        Items like {'code': 'A123', 'w': 100, 'l': 200, 'h': 50}
+    """
+    root = ET.Element('cartons')
+    for carton in cartons:
+        ET.SubElement(
+            root,
+            'carton',
+            code=str(carton.get('code', '')),
+            w=str(carton.get('w', '')),
+            l=str(carton.get('l', '')),
+            h=str(carton.get('h', '')),
+        )
+    tree = ET.ElementTree(root)
+    tree.write(os.path.join(DATA_DIR, 'cartons.xml'), encoding='utf-8', xml_declaration=True)
+    load_cartons.cache_clear()

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ from packing_app.gui.tab_2d import TabPacking2D
 from packing_app.gui.tab_3d import TabBox3D
 from packing_app.gui.tab_pallet import TabPallet
 from packing_app.gui.tab_materials import TabMaterials
+from packing_app.gui.tab_cartons import TabCartons
 
 
 def main():
@@ -19,12 +20,14 @@ def main():
     tab2 = TabBox3D(notebook)
     tab3 = TabPallet(notebook)
     tab4 = TabMaterials(notebook)
+    tab5 = TabCartons(notebook)
     tab1.set_pallet_tab(tab3)
 
     notebook.add(tab1, text="Pakowanie 2D")
     notebook.add(tab2, text="Pakowanie 3D")
     notebook.add(tab3, text="Paletyzacja")
     notebook.add(tab4, text="Materiały")
+    notebook.add(tab5, text="Kartony")
 
     root.mainloop()
 

--- a/packing_app/gui/tab_cartons.py
+++ b/packing_app/gui/tab_cartons.py
@@ -1,0 +1,97 @@
+import tkinter as tk
+from tkinter import ttk, messagebox
+
+from core.utils import load_cartons, save_cartons
+
+
+class TabCartons(ttk.Frame):
+    def __init__(self, parent):
+        super().__init__(parent)
+        self.cartons = [
+            {'code': code, 'w': w, 'l': l, 'h': h}
+            for code, (w, l, h) in load_cartons().items()
+        ]
+        self.selected_index = None
+        self.build_ui()
+
+    def build_ui(self):
+        list_frame = ttk.Frame(self)
+        list_frame.pack(side=tk.LEFT, fill=tk.BOTH, expand=True, padx=5, pady=5)
+
+        self.listbox = tk.Listbox(list_frame, height=15)
+        self.listbox.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        self.listbox.bind("<<ListboxSelect>>", self.on_select)
+
+        scrollbar = ttk.Scrollbar(list_frame, orient="vertical", command=self.listbox.yview)
+        scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
+        self.listbox.config(yscrollcommand=scrollbar.set)
+
+        form = ttk.Frame(self)
+        form.pack(side=tk.LEFT, fill=tk.Y, padx=10, pady=5)
+
+        ttk.Label(form, text="Kod:").grid(row=0, column=0, sticky="e", pady=2)
+        self.code_var = tk.StringVar()
+        ttk.Entry(form, textvariable=self.code_var, width=15).grid(row=0, column=1, pady=2)
+
+        ttk.Label(form, text="W (mm):").grid(row=1, column=0, sticky="e", pady=2)
+        self.w_var = tk.StringVar()
+        ttk.Entry(form, textvariable=self.w_var, width=10).grid(row=1, column=1, pady=2)
+
+        ttk.Label(form, text="L (mm):").grid(row=2, column=0, sticky="e", pady=2)
+        self.l_var = tk.StringVar()
+        ttk.Entry(form, textvariable=self.l_var, width=10).grid(row=2, column=1, pady=2)
+
+        ttk.Label(form, text="H (mm):").grid(row=3, column=0, sticky="e", pady=2)
+        self.h_var = tk.StringVar()
+        ttk.Entry(form, textvariable=self.h_var, width=10).grid(row=3, column=1, pady=2)
+
+        btn_frame = ttk.Frame(form)
+        btn_frame.grid(row=4, column=0, columnspan=2, pady=5)
+        ttk.Button(btn_frame, text="Dodaj / Aktualizuj", command=self.add_update).pack(side=tk.LEFT, padx=2)
+        ttk.Button(btn_frame, text="Usuń", command=self.delete_item).pack(side=tk.LEFT, padx=2)
+        ttk.Button(btn_frame, text="Zapisz", command=self.save).pack(side=tk.LEFT, padx=2)
+
+        self.refresh_list()
+
+    def refresh_list(self):
+        self.listbox.delete(0, tk.END)
+        for c in self.cartons:
+            self.listbox.insert(tk.END, c.get("code", ""))
+
+    def on_select(self, event):
+        if not self.listbox.curselection():
+            self.selected_index = None
+            return
+        idx = self.listbox.curselection()[0]
+        self.selected_index = idx
+        c = self.cartons[idx]
+        self.code_var.set(c.get("code", ""))
+        self.w_var.set(str(c.get("w", "")))
+        self.l_var.set(str(c.get("l", "")))
+        self.h_var.set(str(c.get("h", "")))
+
+    def add_update(self):
+        data = {
+            "code": self.code_var.get(),
+            "w": self.w_var.get(),
+            "l": self.l_var.get(),
+            "h": self.h_var.get(),
+        }
+        if self.selected_index is None:
+            self.cartons.append(data)
+        else:
+            self.cartons[self.selected_index] = data
+        self.refresh_list()
+
+    def delete_item(self):
+        if self.selected_index is not None:
+            del self.cartons[self.selected_index]
+            self.selected_index = None
+            self.refresh_list()
+
+    def save(self):
+        try:
+            save_cartons(self.cartons)
+            messagebox.showinfo("Zapis", "Zapisano dane do pliku.")
+        except Exception as e:
+            messagebox.showerror("Błąd", str(e))


### PR DESCRIPTION
## Summary
- support editing cartons in GUI
- add `save_cartons` helper clearing cache

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68414e7fda008325a0f7f27a66e19c8f