### PR TITLE
Fix carton editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,14 @@ Launch the interface by executing:
 ```bash
 python main.py
 ```
-The window opens with four tabs:
+The window opens with five tabs:
 
 1. **Pakowanie 2D** – compare layouts of small boxes or bottles inside a chosen carton. Select a predefined carton or fill in your own dimensions. The tab shows vertical, horizontal and mixed layouts and lets you add air cushions.
 2. **Pakowanie 3D** – find good carton sizes for a given product using a random search and the list of predefined cartons.
 3. **Paletyzacja** – plan layers of cartons on a pallet. Choose a pallet type and a carton type from drop‑downs, adjust dimensions and transformations and preview the stacking in 2D. The maximum stack height field defaults to **1600&nbsp;mm** (set it to 0 to remove the limit).
 4. **Materiały** – manage a simple list of packaging materials stored in
    `packing_app/data/packaging_materials.xml`.
+5. **Kartony** – edit the list of carton definitions found in
+   `packing_app/data/cartons.xml`.
 
 Predefined cartons and pallets come from the data files and can be selected from the drop‑down menus on each tab.

--- a/core/utils.py
+++ b/core/utils.py
@@ -137,3 +137,40 @@ def save_packaging_materials(materials: list) -> None:
         )
     tree = ET.ElementTree(root)
     tree.write(os.path.join(DATA_DIR, 'packaging_materials.xml'), encoding='utf-8', xml_declaration=True)
+
+
+def load_cartons_list() -> list:
+    """Load cartons from cartons.xml as a list of dictionaries."""
+    root = _load_xml(os.path.join(DATA_DIR, 'cartons.xml'))
+    cartons = []
+    for carton in root.findall('carton'):
+        cartons.append(
+            {
+                'code': carton.get('code', ''),
+                'w': carton.get('w', ''),
+                'l': carton.get('l', ''),
+                'h': carton.get('h', ''),
+                'weight': carton.get('weight', ''),
+            }
+        )
+    return cartons
+
+
+def save_cartons(cartons: list) -> None:
+    """Save cartons list back to cartons.xml and clear caches."""
+    root = ET.Element('cartons')
+    for c in cartons:
+        ET.SubElement(
+            root,
+            'carton',
+            code=c.get('code', ''),
+            w=str(c.get('w', '')),
+            l=str(c.get('l', '')),
+            h=str(c.get('h', '')),
+            weight=str(c.get('weight', '')),
+        )
+    tree = ET.ElementTree(root)
+    tree.write(os.path.join(DATA_DIR, 'cartons.xml'), encoding='utf-8', xml_declaration=True)
+    load_cartons.cache_clear()
+    load_cartons_with_weights.cache_clear()
+

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ from packing_app.gui.tab_2d import TabPacking2D
 from packing_app.gui.tab_3d import TabBox3D
 from packing_app.gui.tab_pallet import TabPallet
 from packing_app.gui.tab_materials import TabMaterials
+from packing_app.gui.tab_cartons import TabCartons
 
 
 def main():
@@ -19,12 +20,14 @@ def main():
     tab2 = TabBox3D(notebook)
     tab3 = TabPallet(notebook)
     tab4 = TabMaterials(notebook)
+    tab5 = TabCartons(notebook)
     tab1.set_pallet_tab(tab3)
 
     notebook.add(tab1, text="Pakowanie 2D")
     notebook.add(tab2, text="Pakowanie 3D")
     notebook.add(tab3, text="Paletyzacja")
     notebook.add(tab4, text="Materiały")
+    notebook.add(tab5, text="Kartony")
 
     root.mainloop()
 

--- a/packing_app/gui/tab_cartons.py
+++ b/packing_app/gui/tab_cartons.py
@@ -1,0 +1,108 @@
+import tkinter as tk
+from tkinter import ttk, messagebox
+
+from core.utils import load_cartons_list, save_cartons
+
+
+class TabCartons(ttk.Frame):
+    """Simple editor for carton definitions stored in cartons.xml."""
+
+    def __init__(self, parent):
+        super().__init__(parent)
+        self.cartons = load_cartons_list()
+        self.selected_index = None
+        self.build_ui()
+
+    def build_ui(self):
+        list_frame = ttk.Frame(self)
+        list_frame.pack(side=tk.LEFT, fill=tk.BOTH, expand=True, padx=5, pady=5)
+
+        self.listbox = tk.Listbox(list_frame, height=15)
+        self.listbox.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        self.listbox.bind("<<ListboxSelect>>", self.on_select)
+
+        scrollbar = ttk.Scrollbar(list_frame, orient="vertical", command=self.listbox.yview)
+        scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
+        self.listbox.config(yscrollcommand=scrollbar.set)
+
+        form = ttk.Frame(self)
+        form.pack(side=tk.LEFT, fill=tk.Y, padx=10, pady=5)
+
+        ttk.Label(form, text="Kod:").grid(row=0, column=0, sticky="e", pady=2)
+        self.code_var = tk.StringVar()
+        ttk.Entry(form, textvariable=self.code_var, width=15).grid(row=0, column=1, pady=2)
+
+        ttk.Label(form, text="W (mm):").grid(row=1, column=0, sticky="e", pady=2)
+        self.w_var = tk.StringVar()
+        ttk.Entry(form, textvariable=self.w_var, width=8).grid(row=1, column=1, pady=2)
+
+        ttk.Label(form, text="L (mm):").grid(row=2, column=0, sticky="e", pady=2)
+        self.l_var = tk.StringVar()
+        ttk.Entry(form, textvariable=self.l_var, width=8).grid(row=2, column=1, pady=2)
+
+        ttk.Label(form, text="H (mm):").grid(row=3, column=0, sticky="e", pady=2)
+        self.h_var = tk.StringVar()
+        ttk.Entry(form, textvariable=self.h_var, width=8).grid(row=3, column=1, pady=2)
+
+        ttk.Label(form, text="Waga:").grid(row=4, column=0, sticky="e", pady=2)
+        self.weight_var = tk.StringVar()
+        ttk.Entry(form, textvariable=self.weight_var, width=8).grid(row=4, column=1, pady=2)
+
+        btn_frame = ttk.Frame(form)
+        btn_frame.grid(row=5, column=0, columnspan=2, pady=5)
+        ttk.Button(btn_frame, text="Dodaj / Aktualizuj", command=self.add_update).pack(side=tk.LEFT, padx=2)
+        ttk.Button(btn_frame, text="Usuń", command=self.delete_item).pack(side=tk.LEFT, padx=2)
+        ttk.Button(btn_frame, text="Zapisz", command=self.save).pack(side=tk.LEFT, padx=2)
+
+        self.refresh_list()
+
+    def refresh_list(self):
+        self.listbox.delete(0, tk.END)
+        for carton in self.cartons:
+            self.listbox.insert(tk.END, carton.get("code", ""))
+
+    def on_select(self, event):
+        if not self.listbox.curselection():
+            self.selected_index = None
+            self.code_var.set("")
+            self.w_var.set("")
+            self.l_var.set("")
+            self.h_var.set("")
+            self.weight_var.set("")
+            return
+        idx = self.listbox.curselection()[0]
+        self.selected_index = idx
+        carton = self.cartons[idx]
+        self.code_var.set(carton.get("code", ""))
+        self.w_var.set(carton.get("w", ""))
+        self.l_var.set(carton.get("l", ""))
+        self.h_var.set(carton.get("h", ""))
+        self.weight_var.set(carton.get("weight", ""))
+
+    def add_update(self):
+        data = {
+            "code": self.code_var.get(),
+            "w": self.w_var.get(),
+            "l": self.l_var.get(),
+            "h": self.h_var.get(),
+            "weight": self.weight_var.get(),
+        }
+        if self.selected_index is None:
+            self.cartons.append(data)
+        else:
+            self.cartons[self.selected_index] = data
+        self.refresh_list()
+
+    def delete_item(self):
+        if self.selected_index is not None:
+            del self.cartons[self.selected_index]
+            self.selected_index = None
+            self.refresh_list()
+
+    def save(self):
+        try:
+            save_cartons(self.cartons)
+            messagebox.showinfo("Zapis", "Zapisano dane do pliku.")
+        except Exception as e:
+            messagebox.showerror("Błąd", str(e))
+


### PR DESCRIPTION
## Summary
- add a simple editor for carton definitions
- support saving/loading carton data in utils
- add new 'Kartony' tab to the GUI
- document the extra tab

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68415e94e0b883258423c0fce76a09bc