### PR TITLE
Add brick pallet layout option

### DIFF
--- a/packing_app/core/algorithms.py
+++ b/packing_app/core/algorithms.py
@@ -16,6 +16,28 @@ def pack_rectangles_2d(width, height, wprod, lprod, margin=0):
             positions.append((x0, y0, wprod, lprod))
     return len(positions), positions
 
+def pack_rectangles_brick(width, height, wprod, lprod, margin=0):
+    """Pack rectangles in a brick (staggered) pattern.
+
+    Alternate rows are offset by half the rectangle width to create a
+    brick-like layout. Only rows that fully fit on the pallet are used.
+    """
+    eff_width = width - margin
+    eff_height = height - margin
+    if eff_width < wprod or eff_height < lprod:
+        return 0, []
+
+    n_rows = int(eff_height // lprod)
+    positions = []
+    for row in range(n_rows):
+        offset = 0 if row % 2 == 0 else wprod / 2
+        max_cols = int((eff_width - offset) // wprod)
+        for col in range(max_cols):
+            x0 = offset + col * wprod
+            y0 = row * lprod
+            positions.append((x0, y0, wprod, lprod))
+    return len(positions), positions
+
 def pack_rectangles_mixed_greedy(width, height, wprod, lprod, margin=0):
     eff_width = width - margin
     eff_height = height - margin

--- a/packing_app/gui/tab_pallet.py
+++ b/packing_app/gui/tab_pallet.py
@@ -4,7 +4,11 @@ import matplotlib
 matplotlib.use("TkAgg")
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
-from packing_app.core.algorithms import pack_rectangles_mixed_greedy, compute_interlocked_layout
+from packing_app.core.algorithms import (
+    pack_rectangles_mixed_greedy,
+    compute_interlocked_layout,
+    pack_rectangles_brick,
+)
 from core.utils import (
     load_cartons,
     load_pallets,
@@ -354,6 +358,14 @@ class TabPallet(ttk.Frame):
         count2, positions2 = pack_rectangles_mixed_greedy(pallet_w, pallet_l, box_l, box_w)
         positions2 = self.center_layout(positions2, pallet_w, pallet_l)
         self.layouts.append((count2, positions2, "Naprzemienny"))
+
+        count_brick, pos_brick = pack_rectangles_brick(pallet_w, pallet_l, box_w, box_l)
+        pos_brick = self.center_layout(pos_brick, pallet_w, pallet_l)
+        self.layouts.append((count_brick, pos_brick, "Ceglany"))
+
+        count_brick_rot, pos_brick_rot = pack_rectangles_brick(pallet_w, pallet_l, box_l, box_w)
+        pos_brick_rot = self.center_layout(pos_brick_rot, pallet_w, pallet_l)
+        self.layouts.append((count_brick_rot, pos_brick_rot, "Ceglany (obracany)"))
 
         _, _, interlocked_layers = compute_interlocked_layout(pallet_w, pallet_l, box_w, box_l, num_layers=2)
         shifted = self.center_layout(interlocked_layers[1], pallet_w, pallet_l)


### PR DESCRIPTION
## Summary
- implement `pack_rectangles_brick` for brick/staggered packing
- generate brick layout variants in pallet computations
- expose brick layout choices in the pallet tab

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_6841699c04648325bf40902cbe22203e