### PR TITLE
Fix maximize_mixed_layout return value

### DIFF
--- a/packing_app/core/algorithms.py
+++ b/packing_app/core/algorithms.py
@@ -318,6 +318,8 @@ def maximize_mixed_layout(w_c, l_c, w_p, l_p, margin, initial_positions):
         if not placed:
             continue
 
+    return count, occupied_positions
+
 def random_box_optimizer_3d(prod_w, prod_l, prod_h, units):
     best_dims = None
     best_score = 0


### PR DESCRIPTION
## Summary
- return a tuple from `maximize_mixed_layout`
- keep `tab_2d` assignment expecting the tuple

## Testing
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_68416e1806b88325b3b2a0421de3b4ba