### PR TITLE
Add brick pallet layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The window opens with five tabs:
 1. **Pakowanie 2D** – compare layouts of small boxes or bottles inside a chosen carton. Select a predefined carton or fill in your own dimensions. The tab shows vertical, horizontal and mixed layouts and lets you add air cushions.
 2. **Pakowanie 3D** – find good carton sizes for a given product using a random search and the list of predefined cartons.
 3. **Paletyzacja** – plan layers of cartons on a pallet. Choose a pallet type and a carton type from drop‑downs, adjust dimensions and transformations and preview the stacking in 2D. The maximum stack height field defaults to **1600&nbsp;mm** (set it to 0 to remove the limit).
+   A new *Cegiełka* layout offsets every second row by half a carton width for better stability.
 4. **Materiały** – manage a simple list of packaging materials stored in
    `packing_app/data/packaging_materials.xml`.
 5. **Kartony** – edit the list of carton definitions found in

--- a/packing_app/core/algorithms.py
+++ b/packing_app/core/algorithms.py
@@ -95,6 +95,28 @@ def compute_interlocked_layout(pallet_w, pallet_l, box_w, box_l, num_layers=4):
 
     return count, base_layers, interlocked_layers
 
+def compute_brick_layout(pallet_w, pallet_l, box_w, box_l, margin=0):
+    """Pack rows with every other row shifted by half box width."""
+    eff_w = pallet_w - margin
+    eff_l = pallet_l - margin
+    if eff_w < box_w or eff_l < box_l:
+        return 0, []
+
+    n_rows = int(eff_l // box_l)
+    positions = []
+    for r in range(n_rows):
+        offset = 0.0
+        if r % 2 == 1 and eff_w >= box_w * 1.5:
+            offset = box_w / 2
+        n_cols = int((eff_w - offset) // box_w)
+        for c in range(n_cols):
+            x = offset + c * box_w
+            y = r * box_l
+            if x + box_w <= eff_w and y + box_l <= eff_l:
+                positions.append((x, y, box_w, box_l))
+
+    return len(positions), positions
+
 def pack_rectangles_mixed_max(width, height, wprod, lprod, margin=0):
     eff_width = width - margin
     eff_height = height - margin

--- a/packing_app/gui/tab_pallet.py
+++ b/packing_app/gui/tab_pallet.py
@@ -4,7 +4,11 @@ import matplotlib
 matplotlib.use("TkAgg")
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
-from packing_app.core.algorithms import pack_rectangles_mixed_greedy, compute_interlocked_layout
+from packing_app.core.algorithms import (
+    pack_rectangles_mixed_greedy,
+    compute_interlocked_layout,
+    compute_brick_layout,
+)
 from core.utils import (
     load_cartons,
     load_pallets,
@@ -214,17 +218,31 @@ class TabPallet(ttk.Frame):
             "Odbicie wzdłuż krótszego boku",
         ]
 
+        prev_odd_layout = getattr(self, "odd_layout_var", None)
+        prev_even_layout = getattr(self, "even_layout_var", None)
+        prev_odd_transform = getattr(self, "odd_transform_var", None)
+        prev_even_transform = getattr(self, "even_transform_var", None)
+
+        odd_default = layout_options[0]
+        even_default = layout_options[0]
+        if prev_odd_layout and prev_odd_layout.get() in layout_options:
+            odd_default = prev_odd_layout.get()
+        if prev_even_layout and prev_even_layout.get() in layout_options:
+            even_default = prev_even_layout.get()
+        odd_tr_default = prev_odd_transform.get() if prev_odd_transform else transform_options[0]
+        even_tr_default = prev_even_transform.get() if prev_even_transform else transform_options[0]
+
         ttk.Label(self.transform_frame, text="Warstwy nieparzyste:").grid(row=0, column=0, padx=5, pady=2)
-        self.odd_layout_var = tk.StringVar(value=layout_options[0])
-        ttk.OptionMenu(self.transform_frame, self.odd_layout_var, layout_options[0], *layout_options, command=self.update_layers).grid(row=0, column=1, padx=5, pady=2)
-        self.odd_transform_var = tk.StringVar(value=transform_options[0])
-        ttk.OptionMenu(self.transform_frame, self.odd_transform_var, transform_options[0], *transform_options, command=self.update_layers).grid(row=0, column=2, padx=5, pady=2)
+        self.odd_layout_var = tk.StringVar(value=odd_default)
+        ttk.OptionMenu(self.transform_frame, self.odd_layout_var, odd_default, *layout_options, command=self.update_layers).grid(row=0, column=1, padx=5, pady=2)
+        self.odd_transform_var = tk.StringVar(value=odd_tr_default)
+        ttk.OptionMenu(self.transform_frame, self.odd_transform_var, odd_tr_default, *transform_options, command=self.update_layers).grid(row=0, column=2, padx=5, pady=2)
 
         ttk.Label(self.transform_frame, text="Warstwy parzyste:").grid(row=1, column=0, padx=5, pady=2)
-        self.even_layout_var = tk.StringVar(value=layout_options[0])
-        ttk.OptionMenu(self.transform_frame, self.even_layout_var, layout_options[0], *layout_options, command=self.update_layers).grid(row=1, column=1, padx=5, pady=2)
-        self.even_transform_var = tk.StringVar(value=transform_options[0])
-        ttk.OptionMenu(self.transform_frame, self.even_transform_var, transform_options[0], *transform_options, command=self.update_layers).grid(row=1, column=2, padx=5, pady=2)
+        self.even_layout_var = tk.StringVar(value=even_default)
+        ttk.OptionMenu(self.transform_frame, self.even_layout_var, even_default, *layout_options, command=self.update_layers).grid(row=1, column=1, padx=5, pady=2)
+        self.even_transform_var = tk.StringVar(value=even_tr_default)
+        ttk.OptionMenu(self.transform_frame, self.even_transform_var, even_tr_default, *transform_options, command=self.update_layers).grid(row=1, column=2, padx=5, pady=2)
 
     def update_layers(self, *args):
         num_layers = getattr(self, 'num_layers', int(parse_dim(self.num_layers_var)))
@@ -376,6 +394,15 @@ class TabPallet(ttk.Frame):
         )
         shifted = self.center_layout(interlocked_layers[1], pallet_w, pallet_l)
         self.layouts.append((len(shifted), shifted, "Przesunięty"))
+
+        count_brick, positions_brick = compute_brick_layout(
+            pallet_w,
+            pallet_l,
+            box_w_ext,
+            box_l_ext,
+        )
+        positions_brick = self.center_layout(positions_brick, pallet_w, pallet_l)
+        self.layouts.append((count_brick, positions_brick, "Cegiełka"))
 
         self.layout_map = {name: idx for idx, (_, __, name) in enumerate(self.layouts)}
         self.update_transform_frame()


### PR DESCRIPTION
## Summary
- implement `compute_brick_layout` for staggering cartons
- expose new algorithm in pallet tab and update UI dropdown logic
- use the brick layout when computing pallet layouts
- document the new option in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68416e204c3c83259a189f4eb2da8ed5