### PR TITLE
Add even/odd layer shift option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The window opens with five tabs:
 
 1. **Pakowanie 2D** – compare layouts of small boxes or bottles inside a chosen carton. Select a predefined carton or fill in your own dimensions. The tab shows vertical, horizontal and mixed layouts and lets you add air cushions.
 2. **Pakowanie 3D** – find good carton sizes for a given product using a random search and the list of predefined cartons.
-3. **Paletyzacja** – plan layers of cartons on a pallet. Choose a pallet type and a carton type from drop‑downs, adjust dimensions and transformations and preview the stacking in 2D. The maximum stack height field defaults to **1600&nbsp;mm** (set it to 0 to remove the limit).
+3. **Paletyzacja** – plan layers of cartons on a pallet. Choose a pallet type and a carton type from drop‑downs, adjust dimensions and transformations and preview the stacking in 2D. The maximum stack height field defaults to **1600&nbsp;mm** (set it to 0 to remove the limit). A checkbox labeled *Przesuwaj warstwy parzyste* controls whether even or odd layers are offset in the interlocked layout.
 4. **Materiały** – manage a simple list of packaging materials stored in
    `packing_app/data/packaging_materials.xml`.
 5. **Kartony** – edit the list of carton definitions found in

--- a/packing_app/gui/tab_pallet.py
+++ b/packing_app/gui/tab_pallet.py
@@ -144,6 +144,14 @@ class TabPallet(ttk.Frame):
         self.include_pallet_height_var = tk.BooleanVar(value=True)
         ttk.Checkbutton(layers_frame, text="Uwzględnij wysokość nośnika", variable=self.include_pallet_height_var, command=self.compute_pallet).grid(row=1, column=2, columnspan=2, padx=5, pady=5, sticky="w")
 
+        self.shift_even_var = tk.BooleanVar(value=True)
+        ttk.Checkbutton(
+            layers_frame,
+            text="Przesuwaj warstwy parzyste",
+            variable=self.shift_even_var,
+            command=self.compute_pallet,
+        ).grid(row=1, column=4, columnspan=2, padx=5, pady=5, sticky="w")
+
         ttk.Label(layers_frame, text="Centrowanie:").grid(row=0, column=2, padx=5, pady=5)
         self.center_var = tk.BooleanVar(value=True)
         ttk.Checkbutton(layers_frame, variable=self.center_var, command=self.compute_pallet).grid(row=0, column=3, padx=5, pady=5)
@@ -373,8 +381,10 @@ class TabPallet(ttk.Frame):
             box_w_ext,
             box_l_ext,
             num_layers=2,
+            shift_even=self.shift_even_var.get(),
         )
-        shifted = self.center_layout(interlocked_layers[1], pallet_w, pallet_l)
+        idx_shifted = 1 if self.shift_even_var.get() else 0
+        shifted = self.center_layout(interlocked_layers[idx_shifted], pallet_w, pallet_l)
         self.layouts.append((len(shifted), shifted, "Przesunięty"))
 
         self.layout_map = {name: idx for idx, (_, __, name) in enumerate(self.layouts)}


### PR DESCRIPTION
## Summary
- allow choosing which layers are shifted in `compute_interlocked_layout`
- expose checkbox in pallet tab to shift even layers
- use checkbox when computing shifted layout
- document the new option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68416e232b388325aa33ca249c968a30