### PR TITLE
Add palletizer pattern selector API

### DIFF
--- a/palletizer_core/__init__.py
+++ b/palletizer_core/__init__.py
@@ -1,0 +1,13 @@
+"""Lightweight palletizing helpers."""
+
+from .models import Carton, Pallet
+from .selector import PatternSelector, PatternScore
+from .sequencer import EvenOddSequencer
+
+__all__ = [
+    "Carton",
+    "Pallet",
+    "PatternSelector",
+    "PatternScore",
+    "EvenOddSequencer",
+]

--- a/palletizer_core/models.py
+++ b/palletizer_core/models.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Carton:
+    """Simple carton dimensions."""
+
+    width: float
+    length: float
+    height: float = 0.0
+
+
+@dataclass
+class Pallet:
+    """Simple pallet dimensions."""
+
+    width: float
+    length: float
+    height: float = 0.0

--- a/palletizer_core/sequencer.py
+++ b/palletizer_core/sequencer.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import List, Tuple
+
+from .models import Carton, Pallet
+
+# Pattern is list of rectangles (x, y, w, l)
+Pattern = List[Tuple[float, float, float, float]]
+
+
+class EvenOddSequencer:
+    """Decide the relative offset / rotation for odd layers."""
+
+    def __init__(self, pattern: Pattern, carton: Carton, pallet: Pallet) -> None:
+        self.pattern = pattern
+        self.carton = carton
+        self.pallet = pallet
+
+    def _shift(self, dx: float, dy: float) -> Pattern:
+        return [
+            (x + dx, y + dy, width, length)
+            for x, y, width, length in self.pattern
+        ]
+
+    def best_shift(self) -> Tuple[Pattern, Pattern]:
+        """Return even and best odd layer."""
+        even = self.pattern
+        shifts = [
+            (0.0, 0.0),
+            (self.carton.width / 2, 0.0),
+            (0.0, self.carton.length / 2),
+            (self.carton.width / 2, self.carton.length / 2),
+        ]
+        best: Pattern | None = None
+        for dx, dy in shifts:
+            candidate = self._shift(dx, dy)
+            if all(
+                0 <= x
+                and 0 <= y
+                and x + width <= self.pallet.width
+                and y + length <= self.pallet.length
+                for x, y, width, length in candidate
+            ):
+                best = candidate
+                break
+        if best is None:
+            best = even
+        return even, best


### PR DESCRIPTION
## Summary
- add new `palletizer_core` package
- generate pallet patterns and score them
- provide an even/odd layer sequencer

## Testing
- `ruff check .`
- `python - <<'PY'
from palletizer_core import Carton, Pallet, PatternSelector, EvenOddSequencer
carton = Carton(width=200, length=150)
pallet = Pallet(width=1200, length=800)
selector = PatternSelector(carton, pallet)
name, pattern, score = selector.best()
print('Best:', name, 'count', len(pattern))
sequencer = EvenOddSequencer(pattern, carton, pallet)
print('Shift result:', len(sequencer.best_shift()[1]))
PY`

------
https://chatgpt.com/codex/tasks/task_e_6841e96e44c88325a1bbef50faf898dd