### PR TITLE
Sync carton selection when moving to pallet

### DIFF
--- a/packing_app/gui/tab_2d.py
+++ b/packing_app/gui/tab_2d.py
@@ -734,6 +734,13 @@ class TabPacking2D(ttk.Frame):
         l_c = self.parse_dim_safe(self.carton_l)
         h_c = self.parse_dim_safe(self.carton_h)
         margin = self.parse_dim_safe(self.margin)
+        carton_code = None
+        val = self.carton_choice.get()
+        if val != "Manual":
+            carton_code = val.split(":")[0]
+        if carton_code:
+            self.pallet_tab.carton_var.set(carton_code)
+            self.pallet_tab.on_carton_selected()
         if self.prod_type.get() == "rectangle":
             w_p = self.parse_dim_safe(self.prod_w)
             l_p = self.parse_dim_safe(self.prod_l)


### PR DESCRIPTION
## Summary
- sync selected carton between the packing tab and the pallet tab when moving a layout

## Testing
- `python -m py_compile packing_app/gui/tab_2d.py`

------
https://chatgpt.com/codex/tasks/task_e_684207d2ebbc8325b2901100479844eb