### PR TITLE
Improve centering with independent groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,5 +23,6 @@ The window opens with five tabs:
 1. **Pakowanie 2D** – compare layouts of small boxes or bottles inside a chosen carton. Select a predefined carton or fill in your own dimensions. The tab shows vertical, horizontal and mixed layouts and lets you add air cushions.
 2. **Pakowanie 3D** – find good carton sizes for a given product using a random search and the list of predefined cartons.
 3. **Paletyzacja** – arrange cartons on a pallet by specifying pallet and box parameters. Choose layout variants, set the number of layers and centering options, then view totals such as stack height and required materials.
+    When centering cartons, the **Cała warstwa** mode centers the entire pattern as one block. In contrast, **Poszczególne obszary** centers every separate group of touching cartons individually. Cartons that only meet at their edges are considered separate groups.
 4. **Materiały** – manage the catalogue of packaging materials. Add, edit or delete items together with their quantities, type, supplier and weight.
 5. **Kartony** – edit predefined carton definitions, modify dimensions and weight or add your own carton codes for use in the other tabs.

--- a/packing_app/gui/tab_pallet.py
+++ b/packing_app/gui/tab_pallet.py
@@ -330,10 +330,10 @@ class TabPallet(ttk.Frame):
             ax, ay, aw, ah = a
             bx, by, bw, bh = b
             return not (
-                ax + aw < bx
-                or bx + bw < ax
-                or ay + ah < by
-                or by + bh < ay
+                ax + aw <= bx
+                or bx + bw <= ax
+                or ay + ah <= by
+                or by + bh <= ay
             )
 
         groups = []


### PR DESCRIPTION
## Summary
- refine carton grouping so edge touching boxes aren't merged
- document the difference between centering modes

## Testing
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_6842be5b7ec48325bbb99f4092a156a0