### PR TITLE
Add runtime weight configuration

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -1,0 +1,4 @@
+layer_eff: 1.0
+cube_eff: 1.0
+stability: 1.0
+grip_changes: 1.0


### PR DESCRIPTION
## Summary
- add default `settings.yaml` with pattern scoring weights
- load weights from YAML in selector
- compute penalties with loaded weights

## Testing
- `python -m pip install -r requirements.txt`
- `python -m pip install pyyaml`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684302d738b88325b9640ee94f680f3b