### PR TITLE
Add edit mode for pallet layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The window opens with five tabs:
 
 1. **Pakowanie 2D** – compare layouts of small boxes or bottles inside a chosen carton. Select a predefined carton or fill in your own dimensions. The tab shows vertical, horizontal and mixed layouts and lets you add air cushions.
 2. **Pakowanie 3D** – find good carton sizes for a given product using a random search and the list of predefined cartons.
-3. **Paletyzacja** – arrange cartons on a pallet by specifying pallet and box parameters. Choose layout variants, set the number of layers and centering options, then view totals such as stack height and required materials.
+3. **Paletyzacja** – arrange cartons on a pallet by specifying pallet and box parameters. Choose layout variants, set the number of layers and centering options, then view totals such as stack height and required materials. The tab also features a **Tryb edycji** checkbox that lets you manually drag cartons on the pallet preview.
     When centering cartons, the **Cała warstwa** mode centers the entire pattern as one block. In contrast, **Poszczególne obszary** centers every separate group of touching cartons individually. Cartons that only meet at their edges are considered separate groups.
 4. **Materiały** – manage the catalogue of packaging materials. Add, edit or delete items together with their quantities, type, supplier and weight.
 5. **Kartony** – edit predefined carton definitions, modify dimensions and weight or add your own carton codes for use in the other tabs.


### PR DESCRIPTION
## Summary
- add `Tryb edycji` checkbox to pallet tab UI
- allow manual dragging of cartons on the pallet
- store Rectangle patches for editing
- connect mouse event handlers when edit mode is active
- document the edit mode in README

## Testing
- `python -m py_compile packing_app/gui/tab_pallet.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684332b9364c8325a151b6e3209f326e