### PR TITLE
Remove unused brick layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The window opens with five tabs:
 
 1. **Pakowanie 2D** – compare layouts of small boxes or bottles inside a chosen carton. Select a predefined carton or fill in your own dimensions. The tab shows vertical, horizontal and mixed layouts and lets you add air cushions.
 2. **Pakowanie 3D** – find good carton sizes for a given product using a random search and the list of predefined cartons.
-3. **Paletyzacja** – arrange cartons on a pallet by specifying pallet and box parameters. Choose layout variants, set the number of layers and centering options, then view totals such as stack height and required materials. The tab also features a **Tryb edycji** checkbox that lets you manually drag cartons on the pallet preview.
+3. **Paletyzacja** – arrange cartons on a pallet by specifying pallet and box parameters. Choose layout variants, set the number of layers and centering options, then view totals such as stack height and required materials. The tab also features a **Tryb edycji** checkbox that lets you manually drag cartons on the pallet preview. Available layouts are *column*, *interlock*, *mixed* and *dense*.
     When centering cartons, the **Cała warstwa** mode centers the entire pattern as one block. In contrast, **Poszczególne obszary** centers every separate group of touching cartons individually. Cartons that only meet at their edges are considered separate groups.
 4. **Materiały** – manage the catalogue of packaging materials. Add, edit or delete items together with their quantities, type, supplier and weight.
 5. **Kartony** – edit predefined carton definitions, modify dimensions and weight or add your own carton codes for use in the other tabs.

--- a/packing_app/core/algorithms.py
+++ b/packing_app/core/algorithms.py
@@ -114,27 +114,6 @@ def compute_interlocked_layout(
 
     return count, base_layers, interlocked_layers
 
-def compute_brick_layout(pallet_w, pallet_l, box_w, box_l, margin=0):
-    """Pack rows with every other row shifted by half box width."""
-    eff_w = pallet_w - margin
-    eff_l = pallet_l - margin
-    if eff_w < box_w or eff_l < box_l:
-        return 0, []
-
-    n_rows = int(eff_l // box_l)
-    positions = []
-    for r in range(n_rows):
-        offset = 0.0
-        if r % 2 == 1 and eff_w >= box_w * 1.5:
-            offset = box_w / 2
-        n_cols = int((eff_w - offset) // box_w)
-        for c in range(n_cols):
-            x = offset + c * box_w
-            y = r * box_l
-            if x + box_w <= eff_w and y + box_l <= eff_l:
-                positions.append((x, y, box_w, box_l))
-
-    return len(positions), positions
 
 def pack_rectangles_mixed_max(width, height, wprod, lprod, margin=0):
     eff_width = width - margin

--- a/palletizer_core/selector.py
+++ b/palletizer_core/selector.py
@@ -93,10 +93,6 @@ class PatternSelector:
         _, patt = algorithms.pack_rectangles_2d(pallet_w, pallet_l, box_w, box_l)
         patterns["column"] = patt
 
-        # brick layout
-        _, patt = algorithms.compute_brick_layout(pallet_w, pallet_l, box_w, box_l)
-        patterns["brick"] = patt
-
         # interlock layout - use first layer of result
         _, _, inter = algorithms.compute_interlocked_layout(pallet_w, pallet_l, box_w, box_l, num_layers=1)
         patterns["interlock"] = inter[0]


### PR DESCRIPTION
## Summary
- drop `compute_brick_layout` function
- stop generating `brick` layout option
- document available pallet patterns in README

## Testing
- `python -m compileall -q .`
- `python -m packing_app.core.algorithms`

------
https://chatgpt.com/codex/tasks/task_e_684340d6bd9483259031a88cdabdf149