### PR TITLE
Enable maximized pallet layout

### DIFF
--- a/packing_app/gui/tab_pallet.py
+++ b/packing_app/gui/tab_pallet.py
@@ -1,6 +1,7 @@
 import tkinter as tk
 from tkinter import ttk, messagebox
 import matplotlib
+
 matplotlib.use("TkAgg")
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
@@ -34,7 +35,9 @@ class TabPallet(ttk.Frame):
         self.predefined_cartons = load_cartons()
         self.predefined_pallets = load_pallets()
         self.carton_weights = {k: v[3] for k, v in load_cartons_with_weights().items()}
-        self.pallet_weights = {p['name']: p['weight'] for p in load_pallets_with_weights()}
+        self.pallet_weights = {
+            p["name"]: p["weight"] for p in load_pallets_with_weights()
+        }
         self.material_weights = load_materials()
         self.pack(fill=tk.BOTH, expand=True)
         self.layouts = []
@@ -72,19 +75,25 @@ class TabPallet(ttk.Frame):
 
         ttk.Label(pallet_frame, text="W (mm):").grid(row=0, column=2, padx=5, pady=5)
         self.pallet_w_var = tk.StringVar(value=str(self.predefined_pallets[0]["w"]))
-        entry_pallet_w = ttk.Entry(pallet_frame, textvariable=self.pallet_w_var, width=10)
+        entry_pallet_w = ttk.Entry(
+            pallet_frame, textvariable=self.pallet_w_var, width=10
+        )
         entry_pallet_w.grid(row=0, column=3, padx=5, pady=5)
         entry_pallet_w.bind("<Return>", self.compute_pallet)
 
         ttk.Label(pallet_frame, text="L (mm):").grid(row=0, column=4, padx=5, pady=5)
         self.pallet_l_var = tk.StringVar(value=str(self.predefined_pallets[0]["l"]))
-        entry_pallet_l = ttk.Entry(pallet_frame, textvariable=self.pallet_l_var, width=10)
+        entry_pallet_l = ttk.Entry(
+            pallet_frame, textvariable=self.pallet_l_var, width=10
+        )
         entry_pallet_l.grid(row=0, column=5, padx=5, pady=5)
         entry_pallet_l.bind("<Return>", self.compute_pallet)
 
         ttk.Label(pallet_frame, text="H (mm):").grid(row=0, column=6, padx=5, pady=5)
         self.pallet_h_var = tk.StringVar(value=str(self.predefined_pallets[0]["h"]))
-        entry_pallet_h = ttk.Entry(pallet_frame, textvariable=self.pallet_h_var, width=10)
+        entry_pallet_h = ttk.Entry(
+            pallet_frame, textvariable=self.pallet_h_var, width=10
+        )
         entry_pallet_h.grid(row=0, column=7, padx=5, pady=5)
         entry_pallet_h.bind("<Return>", self.compute_pallet)
 
@@ -103,24 +112,38 @@ class TabPallet(ttk.Frame):
         carton_menu.grid(row=0, column=1, padx=5, pady=5)
 
         ttk.Label(carton_frame, text="W (mm):").grid(row=0, column=2, padx=5, pady=5)
-        self.box_w_var = tk.StringVar(value=str(self.predefined_cartons[list(self.predefined_cartons.keys())[0]][0]))
+        self.box_w_var = tk.StringVar(
+            value=str(
+                self.predefined_cartons[list(self.predefined_cartons.keys())[0]][0]
+            )
+        )
         entry_box_w = ttk.Entry(carton_frame, textvariable=self.box_w_var, width=10)
         entry_box_w.grid(row=0, column=3, padx=5, pady=5)
         entry_box_w.bind("<Return>", self.compute_pallet)
 
         ttk.Label(carton_frame, text="L (mm):").grid(row=0, column=4, padx=5, pady=5)
-        self.box_l_var = tk.StringVar(value=str(self.predefined_cartons[list(self.predefined_cartons.keys())[0]][1]))
+        self.box_l_var = tk.StringVar(
+            value=str(
+                self.predefined_cartons[list(self.predefined_cartons.keys())[0]][1]
+            )
+        )
         entry_box_l = ttk.Entry(carton_frame, textvariable=self.box_l_var, width=10)
         entry_box_l.grid(row=0, column=5, padx=5, pady=5)
         entry_box_l.bind("<Return>", self.compute_pallet)
 
         ttk.Label(carton_frame, text="H (mm):").grid(row=0, column=6, padx=5, pady=5)
-        self.box_h_var = tk.StringVar(value=str(self.predefined_cartons[list(self.predefined_cartons.keys())[0]][2]))
+        self.box_h_var = tk.StringVar(
+            value=str(
+                self.predefined_cartons[list(self.predefined_cartons.keys())[0]][2]
+            )
+        )
         entry_box_h = ttk.Entry(carton_frame, textvariable=self.box_h_var, width=10)
         entry_box_h.grid(row=0, column=7, padx=5, pady=5)
         entry_box_h.bind("<Return>", self.compute_pallet)
 
-        ttk.Label(carton_frame, text="Grubość tektury (mm):").grid(row=1, column=0, padx=5, pady=5)
+        ttk.Label(carton_frame, text="Grubość tektury (mm):").grid(
+            row=1, column=0, padx=5, pady=5
+        )
         self.cardboard_thickness_var = tk.StringVar(value="3")
         entry_cardboard = ttk.Entry(
             carton_frame,
@@ -132,9 +155,13 @@ class TabPallet(ttk.Frame):
         entry_cardboard.grid(row=1, column=1, padx=5, pady=5)
         entry_cardboard.bind("<Return>", self.compute_pallet)
 
-        ttk.Label(carton_frame, text="Wymiary zewnętrzne (mm):").grid(row=1, column=2, padx=5, pady=5)
+        ttk.Label(carton_frame, text="Wymiary zewnętrzne (mm):").grid(
+            row=1, column=2, padx=5, pady=5
+        )
         self.ext_dims_label = ttk.Label(carton_frame, text="")
-        self.ext_dims_label.grid(row=1, column=3, columnspan=5, padx=5, pady=5, sticky="w")
+        self.ext_dims_label.grid(
+            row=1, column=3, columnspan=5, padx=5, pady=5, sticky="w"
+        )
         self.cardboard_thickness_var.trace_add("write", self.update_external_dimensions)
         self.box_w_var.trace_add("write", self.update_external_dimensions)
         self.box_l_var.trace_add("write", self.update_external_dimensions)
@@ -143,21 +170,34 @@ class TabPallet(ttk.Frame):
         layers_frame = ttk.LabelFrame(self, text="Ustawienia warstw")
         layers_frame.pack(fill=tk.X, padx=10, pady=5)
 
-        ttk.Label(layers_frame, text="Liczba warstw:").grid(row=0, column=0, padx=5, pady=5)
+        ttk.Label(layers_frame, text="Liczba warstw:").grid(
+            row=0, column=0, padx=5, pady=5
+        )
         self.num_layers_var = tk.StringVar(value="1")
-        entry_num_layers = ttk.Entry(layers_frame, textvariable=self.num_layers_var, width=5)
+        entry_num_layers = ttk.Entry(
+            layers_frame, textvariable=self.num_layers_var, width=5
+        )
         entry_num_layers.grid(row=0, column=1, padx=5, pady=5)
         entry_num_layers.bind("<Return>", self.compute_pallet)
 
-        ttk.Label(layers_frame, text="Maksymalna wysokość ułożenia (mm):").grid(row=1, column=0, padx=5, pady=5)
+        ttk.Label(layers_frame, text="Maksymalna wysokość ułożenia (mm):").grid(
+            row=1, column=0, padx=5, pady=5
+        )
         # Default maximum stack height is 1600 mm which roughly corresponds to
         # a common limit for palletized loads. Set to 0 to disable the limit.
         self.max_stack_var = tk.StringVar(value="1600")
-        entry_max_stack = ttk.Entry(layers_frame, textvariable=self.max_stack_var, width=8)
+        entry_max_stack = ttk.Entry(
+            layers_frame, textvariable=self.max_stack_var, width=8
+        )
         entry_max_stack.grid(row=1, column=1, padx=5, pady=5)
         entry_max_stack.bind("<Return>", self.compute_pallet)
         self.include_pallet_height_var = tk.BooleanVar(value=True)
-        ttk.Checkbutton(layers_frame, text="Uwzględnij wysokość nośnika", variable=self.include_pallet_height_var, command=self.compute_pallet).grid(row=1, column=2, columnspan=2, padx=5, pady=5, sticky="w")
+        ttk.Checkbutton(
+            layers_frame,
+            text="Uwzględnij wysokość nośnika",
+            variable=self.include_pallet_height_var,
+            command=self.compute_pallet,
+        ).grid(row=1, column=2, columnspan=2, padx=5, pady=5, sticky="w")
 
         self.shift_even_var = tk.BooleanVar(value=True)
         ttk.Checkbutton(
@@ -167,9 +207,13 @@ class TabPallet(ttk.Frame):
             command=self.compute_pallet,
         ).grid(row=1, column=4, columnspan=2, padx=5, pady=5, sticky="w")
 
-        ttk.Label(layers_frame, text="Centrowanie:").grid(row=0, column=2, padx=5, pady=5)
+        ttk.Label(layers_frame, text="Centrowanie:").grid(
+            row=0, column=2, padx=5, pady=5
+        )
         self.center_var = tk.BooleanVar(value=True)
-        ttk.Checkbutton(layers_frame, variable=self.center_var, command=self.compute_pallet).grid(row=0, column=3, padx=5, pady=5)
+        ttk.Checkbutton(
+            layers_frame, variable=self.center_var, command=self.compute_pallet
+        ).grid(row=0, column=3, padx=5, pady=5)
 
         ttk.Label(layers_frame, text="Tryb:").grid(row=0, column=4, padx=5, pady=5)
         self.center_mode_var = tk.StringVar(value="Cała warstwa")
@@ -182,7 +226,13 @@ class TabPallet(ttk.Frame):
             command=self.compute_pallet,
         ).grid(row=0, column=5, padx=5, pady=5)
 
-
+        self.maximize_mixed = tk.BooleanVar(value=False)
+        ttk.Checkbutton(
+            layers_frame,
+            text="Maksymalizuj mixed",
+            variable=self.maximize_mixed,
+            command=self.compute_pallet,
+        ).grid(row=0, column=6, padx=5, pady=5, sticky="w")
 
         self.transform_frame = ttk.Frame(layers_frame)
         self.transform_frame.grid(row=2, column=0, columnspan=7, padx=5, pady=5)
@@ -190,7 +240,9 @@ class TabPallet(ttk.Frame):
         control_frame = ttk.Frame(self)
         control_frame.pack(fill=tk.X, padx=10, pady=5)
 
-        self.compute_btn = ttk.Button(control_frame, text="Oblicz", command=self.compute_pallet)
+        self.compute_btn = ttk.Button(
+            control_frame, text="Oblicz", command=self.compute_pallet
+        )
         self.compute_btn.pack(side=tk.LEFT, padx=5)
         ttk.Checkbutton(
             control_frame,
@@ -260,38 +312,80 @@ class TabPallet(ttk.Frame):
         prev_even_transform = getattr(self, "even_transform_var", None)
 
         odd_default = (
-            self.best_layout_name if self.best_layout_name in layout_options else layout_options[0]
+            self.best_layout_name
+            if self.best_layout_name in layout_options
+            else layout_options[0]
         )
         even_default = odd_default
         if prev_odd_layout and prev_odd_layout.get() in layout_options:
             odd_default = prev_odd_layout.get()
         if prev_even_layout and prev_even_layout.get() in layout_options:
             even_default = prev_even_layout.get()
-        odd_tr_default = prev_odd_transform.get() if prev_odd_transform else transform_options[0]
-        even_tr_default = prev_even_transform.get() if prev_even_transform else transform_options[0]
+        odd_tr_default = (
+            prev_odd_transform.get() if prev_odd_transform else transform_options[0]
+        )
+        even_tr_default = (
+            prev_even_transform.get() if prev_even_transform else transform_options[0]
+        )
 
-        ttk.Label(self.transform_frame, text="Warstwy nieparzyste:").grid(row=0, column=0, padx=5, pady=2)
+        ttk.Label(self.transform_frame, text="Warstwy nieparzyste:").grid(
+            row=0, column=0, padx=5, pady=2
+        )
         self.odd_layout_var = tk.StringVar(value=odd_default)
-        ttk.OptionMenu(self.transform_frame, self.odd_layout_var, odd_default, *layout_options, command=self.update_layers).grid(row=0, column=1, padx=5, pady=2)
+        ttk.OptionMenu(
+            self.transform_frame,
+            self.odd_layout_var,
+            odd_default,
+            *layout_options,
+            command=self.update_layers,
+        ).grid(row=0, column=1, padx=5, pady=2)
         self.odd_transform_var = tk.StringVar(value=odd_tr_default)
-        ttk.OptionMenu(self.transform_frame, self.odd_transform_var, odd_tr_default, *transform_options, command=self.update_layers).grid(row=0, column=2, padx=5, pady=2)
+        ttk.OptionMenu(
+            self.transform_frame,
+            self.odd_transform_var,
+            odd_tr_default,
+            *transform_options,
+            command=self.update_layers,
+        ).grid(row=0, column=2, padx=5, pady=2)
 
-        ttk.Label(self.transform_frame, text="Warstwy parzyste:").grid(row=1, column=0, padx=5, pady=2)
+        ttk.Label(self.transform_frame, text="Warstwy parzyste:").grid(
+            row=1, column=0, padx=5, pady=2
+        )
         self.even_layout_var = tk.StringVar(value=even_default)
-        ttk.OptionMenu(self.transform_frame, self.even_layout_var, even_default, *layout_options, command=self.update_layers).grid(row=1, column=1, padx=5, pady=2)
+        ttk.OptionMenu(
+            self.transform_frame,
+            self.even_layout_var,
+            even_default,
+            *layout_options,
+            command=self.update_layers,
+        ).grid(row=1, column=1, padx=5, pady=2)
         self.even_transform_var = tk.StringVar(value=even_tr_default)
-        ttk.OptionMenu(self.transform_frame, self.even_transform_var, even_tr_default, *transform_options, command=self.update_layers).grid(row=1, column=2, padx=5, pady=2)
+        ttk.OptionMenu(
+            self.transform_frame,
+            self.even_transform_var,
+            even_tr_default,
+            *transform_options,
+            command=self.update_layers,
+        ).grid(row=1, column=2, padx=5, pady=2)
 
     def update_layers(self, *args):
-        num_layers = getattr(self, 'num_layers', int(parse_dim(self.num_layers_var)))
+        num_layers = getattr(self, "num_layers", int(parse_dim(self.num_layers_var)))
         self.layers = []
         self.transformations = []
         odd_name = self.odd_layout_var.get()
         even_name = self.even_layout_var.get()
         odd_idx = self.layout_map.get(odd_name, 0)
         even_idx = self.layout_map.get(even_name, 0)
-        odd_layout = self.best_odd if odd_name == self.best_layout_name else self.layouts[odd_idx][1]
-        even_layout = self.best_even if even_name == self.best_layout_name else self.layouts[even_idx][1]
+        odd_layout = (
+            self.best_odd
+            if odd_name == self.best_layout_name
+            else self.layouts[odd_idx][1]
+        )
+        even_layout = (
+            self.best_even
+            if even_name == self.best_layout_name
+            else self.layouts[even_idx][1]
+        )
         for i in range(1, num_layers + 1):
             if i % 2 == 1:
                 self.layers.append(odd_layout)
@@ -318,9 +412,9 @@ class TabPallet(ttk.Frame):
         self.box_h_var.set(str(dims[2]))
         self.compute_pallet()
 
-
-
-    def apply_transformation(self, positions, transform, pallet_w, pallet_l, box_w, box_l):
+    def apply_transformation(
+        self, positions, transform, pallet_w, pallet_l, box_w, box_l
+    ):
         new_positions = []
         for x, y, w, h in positions:
             if transform == "Brak":
@@ -350,10 +444,7 @@ class TabPallet(ttk.Frame):
             ax, ay, aw, ah = a
             bx, by, bw, bh = b
             return not (
-                ax + aw <= bx
-                or bx + bw <= ax
-                or ay + ah <= by
-                or by + bh <= ay
+                ax + aw <= bx or bx + bw <= ax or ay + ah <= by or by + bh <= ay
             )
 
         groups = []
@@ -397,7 +488,9 @@ class TabPallet(ttk.Frame):
                 y_max = max(y + h for x, y, w, h in group)
                 offset_x = (pallet_w - (x_max - x_min)) / 2 - x_min
                 offset_y = (pallet_l - (y_max - y_min)) / 2 - y_min
-                centered_positions.extend([(x + offset_x, y + offset_y, w, h) for x, y, w, h in group])
+                centered_positions.extend(
+                    [(x + offset_x, y + offset_y, w, h) for x, y, w, h in group]
+                )
             return centered_positions
 
     def compute_pallet(self, event=None):
@@ -448,13 +541,16 @@ class TabPallet(ttk.Frame):
             carton = Carton(box_w_ext, box_l_ext, box_h)
             pallet = Pallet(pallet_w, pallet_l, pallet_h)
             selector = PatternSelector(carton, pallet)
-            patterns = selector.generate_all()
+            patterns = selector.generate_all(maximize_mixed=self.maximize_mixed.get())
 
             for name, patt in patterns.items():
                 centered = self.center_layout(patt, pallet_w, pallet_l)
-                self.layouts.append((len(centered), centered, name.capitalize()))
+                display = name.replace("_", " ").capitalize()
+                self.layouts.append((len(centered), centered, display))
 
-            best_name, best_pattern, _ = selector.best()
+            best_name, best_pattern, _ = selector.best(
+                maximize_mixed=self.maximize_mixed.get()
+            )
             seq = EvenOddSequencer(best_pattern, carton, pallet)
             even_base, odd_shifted = seq.best_shift()
             if self.shift_even_var.get():
@@ -463,9 +559,11 @@ class TabPallet(ttk.Frame):
             else:
                 self.best_even = self.center_layout(even_base, pallet_w, pallet_l)
                 self.best_odd = self.center_layout(odd_shifted, pallet_w, pallet_l)
-            self.best_layout_name = best_name.capitalize()
+            self.best_layout_name = best_name.replace("_", " ").capitalize()
 
-            self.layout_map = {name: idx for idx, (_, __, name) in enumerate(self.layouts)}
+            self.layout_map = {
+                name: idx for idx, (_, __, name) in enumerate(self.layouts)
+            }
             self.update_transform_frame()
             self.num_layers = num_layers
             self.update_layers()
@@ -484,7 +582,16 @@ class TabPallet(ttk.Frame):
         self.patches = [[] for _ in axes]
         for idx, ax in enumerate(axes):
             ax.clear()
-            ax.add_patch(plt.Rectangle((0, 0), pallet_w, pallet_l, fill=False, edgecolor='black', linewidth=2))
+            ax.add_patch(
+                plt.Rectangle(
+                    (0, 0),
+                    pallet_w,
+                    pallet_l,
+                    fill=False,
+                    edgecolor="black",
+                    linewidth=2,
+                )
+            )
             if idx < len(self.layers):
                 if self.modify_mode_var.get():
                     coords = self.layers[idx]
@@ -494,19 +601,29 @@ class TabPallet(ttk.Frame):
                         self.transformations[idx],
                         pallet_w,
                         pallet_l,
-                        parse_dim(self.box_w_var) + 2 * parse_dim(self.cardboard_thickness_var),
-                        parse_dim(self.box_l_var) + 2 * parse_dim(self.cardboard_thickness_var),
+                        parse_dim(self.box_w_var)
+                        + 2 * parse_dim(self.cardboard_thickness_var),
+                        parse_dim(self.box_l_var)
+                        + 2 * parse_dim(self.cardboard_thickness_var),
                     )
                     self.layers[idx] = coords
                 for i, (x, y, w, h) in enumerate(coords):
-                    color = 'blue' if idx == 0 else 'green'
-                    patch = plt.Rectangle((x, y), w, h, fill=True, facecolor=color, alpha=0.5, edgecolor='black')
+                    color = "blue" if idx == 0 else "green"
+                    patch = plt.Rectangle(
+                        (x, y),
+                        w,
+                        h,
+                        fill=True,
+                        facecolor=color,
+                        alpha=0.5,
+                        edgecolor="black",
+                    )
                     ax.add_patch(patch)
                     self.patches[idx].append((patch, i))
                 ax.set_title(f"{labels[idx]}: {len(self.layers[idx])}")
             ax.set_xlim(-50, pallet_w + 50)
             ax.set_ylim(-50, pallet_l + 50)
-            ax.set_aspect('equal')
+            ax.set_aspect("equal")
         self.canvas.draw()
         if hasattr(self, "status_var"):
             self.status_var.set("")
@@ -515,9 +632,15 @@ class TabPallet(ttk.Frame):
 
     def toggle_edit_mode(self):
         if self.modify_mode_var.get():
-            self.press_cid = self.canvas.mpl_connect("button_press_event", self.on_press)
-            self.motion_cid = self.canvas.mpl_connect("motion_notify_event", self.on_motion)
-            self.release_cid = self.canvas.mpl_connect("button_release_event", self.on_release)
+            self.press_cid = self.canvas.mpl_connect(
+                "button_press_event", self.on_press
+            )
+            self.motion_cid = self.canvas.mpl_connect(
+                "motion_notify_event", self.on_motion
+            )
+            self.release_cid = self.canvas.mpl_connect(
+                "button_release_event", self.on_release
+            )
         else:
             for cid in [self.press_cid, self.motion_cid, self.release_cid]:
                 if cid is not None:
@@ -527,7 +650,10 @@ class TabPallet(ttk.Frame):
             self.draw_pallet()
 
     def on_press(self, event):
-        if not self.modify_mode_var.get() or event.inaxes not in [self.ax_odd, self.ax_even]:
+        if not self.modify_mode_var.get() or event.inaxes not in [
+            self.ax_odd,
+            self.ax_even,
+        ]:
             return
         layer_idx = 0 if event.inaxes is self.ax_odd else 1
         for patch, idx in self.patches[layer_idx]:
@@ -573,9 +699,12 @@ class TabPallet(ttk.Frame):
         num_layers = getattr(self, "num_layers", int(parse_dim(self.num_layers_var)))
         box_h_ext = box_h + 2 * thickness
         cartons_per_odd = len(self.layers[0]) if self.layers else 0
-        cartons_per_even = len(self.layers[1]) if len(self.layers) > 1 else cartons_per_odd
+        cartons_per_even = (
+            len(self.layers[1]) if len(self.layers) > 1 else cartons_per_odd
+        )
         total_cartons = sum(
-            cartons_per_odd if i % 2 == 1 else cartons_per_even for i in range(1, num_layers + 1)
+            cartons_per_odd if i % 2 == 1 else cartons_per_even
+            for i in range(1, num_layers + 1)
         )
         total_products = total_cartons * self.products_per_carton
         stack_height = num_layers * box_h_ext
@@ -602,4 +731,3 @@ class TabPallet(ttk.Frame):
         film_wt = self.film_per_pallet * self.material_weights.get("stretch_film", 0)
         total_mass = carton_wt * total_cartons + tape_wt + film_wt + pallet_wt
         self.weight_label.config(text=f"Masa: {total_mass:.2f} kg")
-


### PR DESCRIPTION
## Summary
- add `maximize_mixed` option to `PatternSelector` generation and scoring
- let TabPallet enable the maximized variant through a checkbox
- display layout names with spaces for readability

## Testing
- `python -m py_compile palletizer_core/selector.py packing_app/gui/tab_pallet.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6843411cb62c83258735bb43d6c774af