### PR TITLE
Use interlock as default layout

### DIFF
--- a/packing_app/gui/tab_pallet.py
+++ b/packing_app/gui/tab_pallet.py
@@ -454,7 +454,8 @@ class TabPallet(ttk.Frame):
                 centered = self.center_layout(patt, pallet_w, pallet_l)
                 self.layouts.append((len(centered), centered, name.capitalize()))
 
-            best_name, best_pattern, _ = selector.best()
+            best_pattern = patterns.get("interlock")
+            best_name = "interlock"
             seq = EvenOddSequencer(best_pattern, carton, pallet)
             even_base, odd_shifted = seq.best_shift()
             if self.shift_even_var.get():
@@ -463,7 +464,7 @@ class TabPallet(ttk.Frame):
             else:
                 self.best_even = self.center_layout(even_base, pallet_w, pallet_l)
                 self.best_odd = self.center_layout(odd_shifted, pallet_w, pallet_l)
-            self.best_layout_name = best_name.capitalize()
+            self.best_layout_name = "Interlock"
 
             self.layout_map = {name: idx for idx, (_, __, name) in enumerate(self.layouts)}
             self.update_transform_frame()


### PR DESCRIPTION
## Summary
- default to the interlock pattern inside pallet calculations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684342f826988325bab4eaccddcc0b99