### PR TITLE
Force interlock layout by default

### DIFF
--- a/packing_app/gui/tab_pallet.py
+++ b/packing_app/gui/tab_pallet.py
@@ -494,6 +494,11 @@ class TabPallet(ttk.Frame):
             return centered_positions
 
     def compute_pallet(self, event=None):
+        """Calculate carton layouts on the pallet.
+
+        The interlock pattern is always selected as the default layout. Other
+        patterns are still generated for manual selection.
+        """
         if hasattr(self, "status_var"):
             self.status_var.set("Obliczanie...")
             self.status_label.update_idletasks()
@@ -548,9 +553,16 @@ class TabPallet(ttk.Frame):
                 display = name.replace("_", " ").capitalize()
                 self.layouts.append((len(centered), centered, display))
 
-            best_name, best_pattern, _ = selector.best(
-                maximize_mixed=self.maximize_mixed.get()
-            )
+            # Force the interlock pattern to be the default selection
+            interlock_pattern = patterns.get("interlock")
+            if interlock_pattern is None:
+                best_name, best_pattern, _ = selector.best(
+                    maximize_mixed=self.maximize_mixed.get()
+                )
+            else:
+                best_name = "interlock"
+                best_pattern = interlock_pattern
+
             seq = EvenOddSequencer(best_pattern, carton, pallet)
             even_base, odd_shifted = seq.best_shift()
             if self.shift_even_var.get():

--- a/palletizer_core/sequencer.py
+++ b/palletizer_core/sequencer.py
@@ -25,11 +25,13 @@ class EvenOddSequencer:
     def best_shift(self) -> Tuple[Pattern, Pattern]:
         """Return even and best odd layer."""
         even = self.pattern
+        # Try offsets that interlock alternating layers. Skip the no-op shift
+        # to avoid immediately selecting it as ``best``.
         shifts = [
-            (0.0, 0.0),
             (self.carton.width / 2, 0.0),
             (0.0, self.carton.length / 2),
             (self.carton.width / 2, self.carton.length / 2),
+            (0.0, 0.0),
         ]
         best: Pattern | None = None
         for dx, dy in shifts:


### PR DESCRIPTION
## Summary
- default to the interlock layout when computing pallet patterns
- improve `EvenOddSequencer.best_shift` so it actually tries shifting layers
- document the pallet computation

## Testing
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_684345b7211c8325b9b8a8bffcbdb9e0