### PR TITLE
Ensure interlock layout name consistency

### DIFF
--- a/tests/test_interlock_default.py
+++ b/tests/test_interlock_default.py
@@ -1,0 +1,38 @@
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from palletizer_core import Carton, Pallet, PatternSelector
+from packing_app.gui.tab_pallet import TabPallet
+
+
+class Dummy:
+    group_cartons = TabPallet.group_cartons
+    center_layout = TabPallet.center_layout
+    _get_default_layout = TabPallet._get_default_layout
+
+    def __init__(self):
+        def var(val):
+            return types.SimpleNamespace(get=lambda: val)
+        self.maximize_mixed = var(False)
+        self.shift_even_var = var(False)
+        self.center_var = var(False)
+        self.center_mode_var = var("Cała warstwa")
+
+
+def test_interlock_selected_by_default():
+    dummy = Dummy()
+    carton = Carton(200, 200, 0)
+    pallet = Pallet(800, 600, 0)
+    selector = PatternSelector(carton, pallet)
+
+    patterns, name, _, _ = dummy._get_default_layout(
+        selector, carton, pallet, pallet.width, pallet.length
+    )
+
+    assert "interlock" in patterns and patterns["interlock"], "interlock layout missing"
+    assert name == "Interlock"
+


### PR DESCRIPTION
## Summary
- centralize layout selection logic in `TabPallet._get_default_layout`
- refactor `compute_pallet` to use the helper and keep `best_layout_name` consistent
- add a regression test for default interlock layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68434a2b55a08325adb81b594641bf29