### PR TITLE
Fix external dimensions label initialization

### DIFF
--- a/packing_app/gui/tab_pallet.py
+++ b/packing_app/gui/tab_pallet.py
@@ -166,6 +166,7 @@ class TabPallet(ttk.Frame):
         self.box_w_var.trace_add("write", self.update_external_dimensions)
         self.box_l_var.trace_add("write", self.update_external_dimensions)
         self.box_h_var.trace_add("write", self.update_external_dimensions)
+        self.update_external_dimensions()
 
         layers_frame = ttk.LabelFrame(self, text="Ustawienia warstw")
         layers_frame.pack(fill=tk.X, padx=10, pady=5)


### PR DESCRIPTION
## Summary
- set up external dimensions label on startup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68434dfe40b48325960522e2a2a91bd0