### PR TITLE
Add early fit check for maximize_mixed_layout

### DIFF
--- a/packing_app/core/algorithms.py
+++ b/packing_app/core/algorithms.py
@@ -263,6 +263,8 @@ def place_air_cushions(w_c, l_c, occupied_positions, cushion_w=37, cushion_l=175
 def maximize_mixed_layout(w_c, l_c, w_p, l_p, margin, initial_positions):
     eff_w = w_c - margin
     eff_l = l_c - margin
+    if not ((w_p <= eff_w and l_p <= eff_l) or (l_p <= eff_w and w_p <= eff_l)):
+        return 0, []
     free_areas = [(0, 0, eff_w, eff_l)]
     occupied_positions = initial_positions.copy()
     count = len(occupied_positions)

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -1,0 +1,12 @@
+import pytest
+
+from packing_app.core.algorithms import maximize_mixed_layout
+
+
+def test_maximize_mixed_layout_small_pallet_returns_empty():
+    # carton dims larger than pallet dims so no orientation fits
+    count, positions = maximize_mixed_layout(
+        w_c=100, l_c=100, w_p=150, l_p=150, margin=0, initial_positions=[]
+    )
+    assert count == 0
+    assert positions == []


### PR DESCRIPTION
## Summary
- guard `maximize_mixed_layout` against oversized cartons
- add regression test for early return when pallet is too small

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684358a85af88325b103982ab485c336