### PR TITLE
Prevent layout collisions on centering

### DIFF
--- a/packing_app/gui/tab_pallet.py
+++ b/packing_app/gui/tab_pallet.py
@@ -493,6 +493,20 @@ class TabPallet(ttk.Frame):
                 centered_positions.extend(
                     [(x + offset_x, y + offset_y, w, h) for x, y, w, h in group]
                 )
+
+            # If centering individual groups makes them collide, fall back to
+            # centering the entire layer instead of merging the groups.
+            if len(self.group_cartons(centered_positions)) != len(groups):
+                x_min = min(x for x, y, w, h in positions)
+                x_max = max(x + w for x, y, w, h in positions)
+                y_min = min(y for x, y, w, h in positions)
+                y_max = max(y + h for x, y, w, h in positions)
+                offset_x = (pallet_w - (x_max - x_min)) / 2 - x_min
+                offset_y = (pallet_l - (y_max - y_min)) / 2 - y_min
+                return [
+                    (x + offset_x, y + offset_y, w, h)
+                    for x, y, w, h in positions
+                ]
             return centered_positions
 
     def _get_default_layout(

--- a/tests/test_interlock_default.py
+++ b/tests/test_interlock_default.py
@@ -36,3 +36,20 @@ def test_interlock_selected_by_default():
     assert "interlock" in patterns and patterns["interlock"], "interlock layout missing"
     assert name == "Interlock"
 
+
+def test_center_layout_keeps_groups_separate():
+    dummy = Dummy()
+    # Enable centering and use the per-area mode
+    dummy.center_var = types.SimpleNamespace(get=lambda: True)
+    dummy.center_mode_var = types.SimpleNamespace(get=lambda: "Poszczególne obszary")
+
+    # Two groups positioned at opposite sides of the pallet
+    positions = [(0, 0, 50, 50), (150, 0, 50, 50)]
+    pallet_w, pallet_l = 200, 100
+
+    centered = dummy.center_layout(positions, pallet_w, pallet_l)
+    groups_after = dummy.group_cartons(centered)
+
+    # Groups should remain disjoint after centering
+    assert len(groups_after) == 2
+


### PR DESCRIPTION
## Summary
- improve centering logic so overlapping groups trigger whole-layer centering
- test that groups remain separate when centered per-area

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684358c1569c83259bf1806ed425e714