### PR TITLE
Enhance stability scoring

### DIFF
--- a/tests/test_palletizer_core.py
+++ b/tests/test_palletizer_core.py
@@ -48,3 +48,31 @@ def test_even_odd_sequencer_shift():
 
     shifted = [(x + carton.width / 2, y, w, l) for x, y, w, l in even]
     assert odd == shifted
+
+
+def test_stability_prefers_centered_layout():
+    carton = Carton(width=50, length=50)
+    pallet = Pallet(width=100, length=100)
+    selector = PatternSelector(carton, pallet)
+
+    centered = [(0, 0, 50, 50), (50, 50, 50, 50)]
+    offcenter = [(0, 0, 50, 50), (0, 50, 50, 50)]
+
+    c_score = selector.score(centered)
+    o_score = selector.score(offcenter)
+
+    assert c_score.stability > o_score.stability
+
+
+def test_stability_penalizes_overhang():
+    carton = Carton(width=50, length=50)
+    pallet = Pallet(width=100, length=100)
+    selector = PatternSelector(carton, pallet)
+
+    inside = [(0, 0, 50, 50)]
+    overhang = [(60, 0, 50, 50)]
+
+    inside_score = selector.score(inside)
+    over_score = selector.score(overhang)
+
+    assert inside_score.stability > over_score.stability


### PR DESCRIPTION
## Summary
- compute pallet pattern stability from center of mass and overhang
- clarify stability metric in comments
- test new stability behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847d7a7acc88325a2a44186fb6fd0ad