### PR TITLE
Add pallet rotation transform

### DIFF
--- a/packing_app/gui/tab_pallet.py
+++ b/packing_app/gui/tab_pallet.py
@@ -318,6 +318,7 @@ class TabPallet(ttk.Frame):
             "Brak",
             "Odbicie wzdłuż dłuższego boku",
             "Odbicie wzdłuż krótszego boku",
+            "Rotacja 90°",
         ]
 
         prev_odd_layout = getattr(self, "odd_layout_var", None)
@@ -450,19 +451,46 @@ class TabPallet(ttk.Frame):
                     new_x = x
                     new_y = pallet_l - y - h
                 new_positions.append((new_x, new_y, w, h))
+            elif transform == "Rotacja 90°":
+                cx, cy = pallet_w / 2, pallet_l / 2
+                center_x = x + w / 2
+                center_y = y + h / 2
+                rot_cx = cx + (center_y - cy)
+                rot_cy = cy - (center_x - cx)
+                new_w, new_h = h, w
+                new_x = rot_cx - new_w / 2
+                new_y = rot_cy - new_h / 2
+                new_positions.append((new_x, new_y, new_w, new_h))
         return new_positions
 
     def inverse_transformation(
         self, positions, transform, pallet_w, pallet_l, box_w, box_l
     ):
         """Reverse the transformation applied to the positions."""
-        # For the current set of transformations (mirror flips) the inverse is
-        # identical to the forward operation.  Having a dedicated helper keeps
-        # the logic explicit and makes it easier to extend if new transforms
-        # are introduced in the future.
-        return self.apply_transformation(
-            positions, transform, pallet_w, pallet_l, box_w, box_l
-        )
+        new_positions = []
+        for x, y, w, h in positions:
+            if transform == "Rotacja 90°":
+                cx, cy = pallet_w / 2, pallet_l / 2
+                center_x = x + w / 2
+                center_y = y + h / 2
+                rot_cx = cx - (center_y - cy)
+                rot_cy = cy + (center_x - cx)
+                new_w, new_h = h, w
+                new_x = rot_cx - new_w / 2
+                new_y = rot_cy - new_h / 2
+                new_positions.append((new_x, new_y, new_w, new_h))
+            else:
+                new_positions.extend(
+                    self.apply_transformation(
+                        [(x, y, w, h)],
+                        transform,
+                        pallet_w,
+                        pallet_l,
+                        box_w,
+                        box_l,
+                    )
+                )
+        return new_positions
 
     def group_cartons(self, positions):
         """Group cartons that touch or overlap using AABB collision detection."""

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -1,0 +1,14 @@
+import types
+from packing_app.gui.tab_pallet import TabPallet
+
+def test_rotation_inverse():
+    dummy = types.SimpleNamespace()
+    positions = [(10.0, 20.0, 30.0, 40.0)]
+    pallet_w, pallet_l = 100.0, 80.0
+    rotated = TabPallet.apply_transformation(
+        dummy, positions, "Rotacja 90°", pallet_w, pallet_l, 30.0, 40.0
+    )
+    reverted = TabPallet.inverse_transformation(
+        dummy, rotated, "Rotacja 90°", pallet_w, pallet_l, 30.0, 40.0
+    )
+    assert reverted == positions


### PR DESCRIPTION
## Summary
- extend transform options to include 90° rotation
- rotate carton coordinates about pallet centre
- implement inverse rotation helper
- test that rotation transform is invertible

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847d793fef883258156027d8f4bd5dc