### PR TITLE
Synchronize layer edits

### DIFF
--- a/packing_app/gui/tab_pallet.py
+++ b/packing_app/gui/tab_pallet.py
@@ -942,6 +942,9 @@ class TabPallet(ttk.Frame):
             orig_x, orig_y, w, h, pallet_w, pallet_l, other_boxes
         )
         self.layers[layer_idx][idx] = (snap_x, snap_y, w, h)
+        other_layer = 1 - layer_idx
+        if other_layer < len(self.layers) and idx < len(self.layers[other_layer]):
+            self.layers[other_layer][idx] = (snap_x, snap_y, w, h)
         self.selected_patch = None
         self.draw_pallet()
         self.update_summary()
@@ -955,6 +958,9 @@ class TabPallet(ttk.Frame):
             w = parse_dim(self.box_w_var) + 2 * thickness
             h = parse_dim(self.box_l_var) + 2 * thickness
         self.layers[layer_idx].append((pos[0], pos[1], w, h))
+        other_layer = 1 - layer_idx
+        if other_layer < len(self.layers):
+            self.layers[other_layer].append((pos[0], pos[1], w, h))
         self.draw_pallet()
         self.update_summary()
 
@@ -965,6 +971,9 @@ class TabPallet(ttk.Frame):
         if self.selected_patch:
             layer_idx, idx, _ = self.selected_patch
             del self.layers[layer_idx][idx]
+            other_layer = 1 - layer_idx
+            if other_layer < len(self.layers) and idx < len(self.layers[other_layer]):
+                del self.layers[other_layer][idx]
             self.selected_patch = None
             self.draw_pallet()
             self.update_summary()

--- a/tests/test_gui_sync.py
+++ b/tests/test_gui_sync.py
@@ -1,0 +1,48 @@
+import types
+from packing_app.gui.tab_pallet import TabPallet
+
+class DummyPatch:
+    def __init__(self, x=0, y=0):
+        self._xy = (x, y)
+    def get_xy(self):
+        return self._xy
+    def set_xy(self, xy):
+        self._xy = xy
+
+def var(val):
+    return types.SimpleNamespace(get=lambda: str(val))
+
+def make_dummy():
+    d = types.SimpleNamespace()
+    d.pallet_w_var = var(100)
+    d.pallet_l_var = var(100)
+    d.cardboard_thickness_var = var(0)
+    d.box_w_var = var(10)
+    d.box_l_var = var(10)
+    d.transformations = ["Brak", "Brak"]
+    d.layers = [[(0, 0, 10, 10)], [(0, 0, 10, 10)]]
+    d.snap_position = lambda x, y, w, h, pw, pl, other: (x, y)
+    d.inverse_transformation = lambda pos, trans, pw, pl, bw, bl: pos
+    d.draw_pallet = lambda: None
+    d.update_summary = lambda: None
+    d.selected_patch = None
+    return d
+
+def test_on_release_syncs_layers():
+    dummy = make_dummy()
+    dummy.selected_patch = (0, 0, DummyPatch(5, 5))
+    TabPallet.on_release(dummy, None)
+    assert dummy.layers[0][0][:2] == (5, 5)
+    assert dummy.layers[1][0][:2] == (5, 5)
+
+def test_insert_and_delete_sync():
+    dummy = make_dummy()
+    TabPallet.insert_carton(dummy, 0, (10, 10))
+    assert len(dummy.layers[0]) == 2
+    assert len(dummy.layers[1]) == 2
+    assert dummy.layers[0][-1][:2] == (10, 10)
+    assert dummy.layers[1][-1][:2] == (10, 10)
+    dummy.selected_patch = (0, 0, DummyPatch())
+    TabPallet.delete_selected_carton(dummy)
+    assert len(dummy.layers[0]) == 1
+    assert len(dummy.layers[1]) == 1


### PR DESCRIPTION
## Summary
- keep odd/even layers in sync when moving cartons
- mirror inserts and deletions across layers
- test that layer updates are synchronized

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684814ebeef883259f81eb08bb65dd4d