### PR TITLE
Add slip sheet handling

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -174,3 +174,24 @@ def save_cartons(cartons: list) -> None:
     load_cartons.cache_clear()
     load_cartons_with_weights.cache_clear()
 
+
+def load_slip_sheets() -> list:
+    """Load slip sheet definitions from slip_sheets.xml."""
+    path = os.path.join(DATA_DIR, "slip_sheets.xml")
+    if not os.path.exists(path):
+        return []
+    root = _load_xml(path)
+    sheets = []
+    for sheet in root.findall("sheet"):
+        sheets.append({"weight": sheet.get("weight", "")})
+    return sheets
+
+
+def save_slip_sheets(sheets: list) -> None:
+    """Save slip sheet definitions back to slip_sheets.xml."""
+    root = ET.Element("slip_sheets")
+    for sheet in sheets:
+        ET.SubElement(root, "sheet", weight=str(sheet.get("weight", "")))
+    tree = ET.ElementTree(root)
+    tree.write(os.path.join(DATA_DIR, "slip_sheets.xml"), encoding="utf-8", xml_declaration=True)
+

--- a/packing_app/data/slip_sheets.xml
+++ b/packing_app/data/slip_sheets.xml
@@ -1,0 +1,4 @@
+<slip_sheets>
+    <sheet weight="0.2" />
+    <sheet weight="0.4" />
+</slip_sheets>

--- a/packing_app/gui/tab_pallet.py
+++ b/packing_app/gui/tab_pallet.py
@@ -239,19 +239,19 @@ class TabPallet(ttk.Frame):
             command=self.compute_pallet,
         ).grid(row=0, column=6, padx=5, pady=5, sticky="w")
 
-        ttk.Label(layers_frame, text="Grubość przekładki (mm):").grid(
+        ttk.Label(layers_frame, text="Liczba przekładek:").grid(
             row=2, column=0, padx=5, pady=5
         )
-        self.slip_thickness_var = tk.StringVar(value="0")
-        entry_slip_thickness = ttk.Entry(
+        self.slip_count_var = tk.StringVar(value="0")
+        entry_slip_count = ttk.Entry(
             layers_frame,
-            textvariable=self.slip_thickness_var,
+            textvariable=self.slip_count_var,
             width=5,
             validate="key",
             validatecommand=(self.register(self.validate_number), "%P"),
         )
-        entry_slip_thickness.grid(row=2, column=1, padx=5, pady=5)
-        entry_slip_thickness.bind("<Return>", self.compute_pallet)
+        entry_slip_count.grid(row=2, column=1, padx=5, pady=5)
+        entry_slip_count.bind("<Return>", self.compute_pallet)
 
         ttk.Label(layers_frame, text="Waga przekładki (kg):").grid(
             row=2, column=2, padx=5, pady=5
@@ -689,7 +689,7 @@ class TabPallet(ttk.Frame):
             box_l = parse_dim(self.box_l_var)
             box_h = parse_dim(self.box_h_var)
             thickness = parse_dim(self.cardboard_thickness_var)
-            slip_thickness = parse_dim(self.slip_thickness_var)
+            slip_count = int(parse_dim(self.slip_count_var))
             box_w_ext = box_w + 2 * thickness
             box_l_ext = box_l + 2 * thickness
             num_layers = int(parse_dim(self.num_layers_var))
@@ -700,9 +700,9 @@ class TabPallet(ttk.Frame):
                     pallet_h if self.include_pallet_height_var.get() else 0
                 )
                 box_h_ext = box_h + 2 * thickness
-                layer_height = box_h_ext + slip_thickness
+                layer_height = box_h_ext
                 if layer_height > 0:
-                    num_layers = max(int((avail + slip_thickness) // layer_height), 0)
+                    num_layers = max(int(avail // layer_height), 0)
                     self.num_layers_var.set(str(num_layers))
 
             if (
@@ -765,7 +765,7 @@ class TabPallet(ttk.Frame):
             }
             self.update_transform_frame()
             self.num_layers = num_layers
-            self.slip_sheet_layers = list(range(1, num_layers))
+            self.slip_sheet_layers = list(range(1, slip_count + 1))
             self.update_layers()
             self.update_summary()
         finally:
@@ -999,7 +999,7 @@ class TabPallet(ttk.Frame):
         box_l = parse_dim(self.box_l_var)
         box_h = parse_dim(self.box_h_var)
         thickness = parse_dim(self.cardboard_thickness_var)
-        slip_thickness = parse_dim(self.slip_thickness_var)
+        slip_count = int(parse_dim(self.slip_count_var))
         slip_weight = parse_dim(self.slip_weight_var)
 
         num_layers = getattr(self, "num_layers", int(parse_dim(self.num_layers_var)))
@@ -1013,8 +1013,8 @@ class TabPallet(ttk.Frame):
             for i in range(1, num_layers + 1)
         )
         total_products = total_cartons * self.products_per_carton
-        num_slip = len(self.slip_sheet_layers)
-        stack_height = num_layers * box_h_ext + num_slip * slip_thickness
+        num_slip = slip_count
+        stack_height = num_layers * box_h_ext
         if self.include_pallet_height_var.get():
             stack_height += pallet_h
 


### PR DESCRIPTION
## Summary
- allow specifying slip sheet count not thickness
- ignore slip sheet thickness in height and compute weight using count
- add slip sheet XML data and utilities

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684814f0bbac83258d7ad447fd44a936