### PR TITLE
Add packaging editors for multiple material categories

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -174,3 +174,72 @@ def save_cartons(cartons: list) -> None:
     load_cartons.cache_clear()
     load_cartons_with_weights.cache_clear()
 
+
+def _load_generic_materials(filename: str) -> list:
+    """Helper to load material lists from XML files."""
+    path = os.path.join(DATA_DIR, filename)
+    if not os.path.exists(path):
+        return []
+    root = _load_xml(path)
+    materials = []
+    for mat in root.findall('material'):
+        materials.append(
+            {
+                'name': mat.get('name', ''),
+                'quantity': mat.get('quantity', ''),
+                'comment': mat.get('comment', ''),
+                'weight': mat.get('weight', ''),
+                'type': mat.get('type', ''),
+                'supplier': mat.get('supplier', ''),
+            }
+        )
+    return materials
+
+
+def _save_generic_materials(filename: str, materials: list) -> None:
+    """Helper to save material lists to XML files."""
+    root = ET.Element('materials')
+    for mat in materials:
+        ET.SubElement(
+            root,
+            'material',
+            name=mat.get('name', ''),
+            quantity=mat.get('quantity', ''),
+            comment=mat.get('comment', ''),
+            weight=mat.get('weight', ''),
+            type=mat.get('type', ''),
+            supplier=mat.get('supplier', ''),
+        )
+    tree = ET.ElementTree(root)
+    tree.write(os.path.join(DATA_DIR, filename), encoding='utf-8', xml_declaration=True)
+
+
+def load_direct_packaging() -> list:
+    """Load direct packaging materials from direct_packaging.xml."""
+    return _load_generic_materials('direct_packaging.xml')
+
+
+def save_direct_packaging(materials: list) -> None:
+    """Save direct packaging materials to direct_packaging.xml."""
+    _save_generic_materials('direct_packaging.xml', materials)
+
+
+def load_indirect_packaging() -> list:
+    """Load indirect packaging materials from indirect_packaging.xml."""
+    return _load_generic_materials('indirect_packaging.xml')
+
+
+def save_indirect_packaging(materials: list) -> None:
+    """Save indirect packaging materials to indirect_packaging.xml."""
+    _save_generic_materials('indirect_packaging.xml', materials)
+
+
+def load_auxiliary_materials() -> list:
+    """Load auxiliary materials from auxiliary_materials.xml."""
+    return _load_generic_materials('auxiliary_materials.xml')
+
+
+def save_auxiliary_materials(materials: list) -> None:
+    """Save auxiliary materials to auxiliary_materials.xml."""
+    _save_generic_materials('auxiliary_materials.xml', materials)
+

--- a/main.py
+++ b/main.py
@@ -4,8 +4,10 @@ from tkinter import ttk
 from packing_app.gui.tab_2d import TabPacking2D
 from packing_app.gui.tab_3d import TabBox3D
 from packing_app.gui.tab_pallet import TabPallet
-from packing_app.gui.tab_materials import TabMaterials
 from packing_app.gui.tab_cartons import TabCartons
+from packing_app.gui.tab_direct_packaging import TabDirectPackaging
+from packing_app.gui.tab_indirect_packaging import TabIndirectPackaging
+from packing_app.gui.tab_auxiliary import TabAuxiliaryMaterials
 
 
 def main():
@@ -19,15 +21,19 @@ def main():
     tab1 = TabPacking2D(notebook)
     tab2 = TabBox3D(notebook)
     tab3 = TabPallet(notebook)
-    tab4 = TabMaterials(notebook)
-    tab5 = TabCartons(notebook)
+    tab4 = TabDirectPackaging(notebook)
+    tab5 = TabIndirectPackaging(notebook)
+    tab6 = TabAuxiliaryMaterials(notebook)
+    tab7 = TabCartons(notebook)
     tab1.set_pallet_tab(tab3)
 
     notebook.add(tab1, text="Pakowanie 2D")
     notebook.add(tab2, text="Pakowanie 3D")
     notebook.add(tab3, text="Paletyzacja")
-    notebook.add(tab4, text="Materiały")
-    notebook.add(tab5, text="Kartony")
+    notebook.add(tab4, text="Opakowanie bezpośrednie")
+    notebook.add(tab5, text="Opakowanie pośrednie")
+    notebook.add(tab6, text="Materiały pomocnicze")
+    notebook.add(tab7, text="Kartony")
 
     root.mainloop()
 

--- a/packing_app/data/auxiliary_materials.xml
+++ b/packing_app/data/auxiliary_materials.xml
@@ -1,0 +1,4 @@
+<materials>
+  <material name="tape" quantity="2 rolls" comment="transparent" weight="0.5" type="adhesive" supplier="Supplier A"/>
+  <material name="bubble_wrap" quantity="10 m" comment="large bubbles" weight="1.2" type="padding" supplier="Supplier B"/>
+</materials>

--- a/packing_app/data/direct_packaging.xml
+++ b/packing_app/data/direct_packaging.xml
@@ -1,0 +1,4 @@
+<materials>
+  <material name="tape" quantity="2 rolls" comment="transparent" weight="0.5" type="adhesive" supplier="Supplier A"/>
+  <material name="bubble_wrap" quantity="10 m" comment="large bubbles" weight="1.2" type="padding" supplier="Supplier B"/>
+</materials>

--- a/packing_app/data/indirect_packaging.xml
+++ b/packing_app/data/indirect_packaging.xml
@@ -1,0 +1,4 @@
+<materials>
+  <material name="tape" quantity="2 rolls" comment="transparent" weight="0.5" type="adhesive" supplier="Supplier A"/>
+  <material name="bubble_wrap" quantity="10 m" comment="large bubbles" weight="1.2" type="padding" supplier="Supplier B"/>
+</materials>

--- a/packing_app/gui/tab_auxiliary.py
+++ b/packing_app/gui/tab_auxiliary.py
@@ -1,0 +1,130 @@
+import tkinter as tk
+from tkinter import ttk, messagebox
+
+from core.utils import load_auxiliary_materials, save_auxiliary_materials
+
+
+class TabAuxiliaryMaterials(ttk.Frame):
+    """Editor for auxiliary materials."""
+
+    def __init__(self, parent):
+        super().__init__(parent)
+        self.materials = load_auxiliary_materials()
+        self.selected_index = None
+        self.build_ui()
+
+    def build_ui(self):
+        list_frame = ttk.Frame(self)
+        list_frame.pack(side=tk.LEFT, fill=tk.BOTH, expand=True, padx=5, pady=5)
+
+        self.listbox = tk.Listbox(list_frame, height=15)
+        self.listbox.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        self.listbox.bind("<<ListboxSelect>>", self.on_select)
+
+        scrollbar = ttk.Scrollbar(list_frame, orient="vertical", command=self.listbox.yview)
+        scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
+        self.listbox.config(yscrollcommand=scrollbar.set)
+
+        form = ttk.Frame(self)
+        form.pack(side=tk.LEFT, fill=tk.Y, padx=10, pady=5)
+
+        ttk.Label(form, text="Nazwa:").grid(row=0, column=0, sticky="e", pady=2)
+        self.name_var = tk.StringVar()
+        ttk.Entry(form, textvariable=self.name_var, width=25).grid(row=0, column=1, pady=2)
+
+        ttk.Label(form, text="Ilość/Jednostka:").grid(row=1, column=0, sticky="e", pady=2)
+        self.qty_var = tk.StringVar()
+        ttk.Entry(form, textvariable=self.qty_var, width=25).grid(row=1, column=1, pady=2)
+
+        ttk.Label(form, text="Komentarz:").grid(row=2, column=0, sticky="e", pady=2)
+        self.comment_var = tk.StringVar()
+        ttk.Entry(form, textvariable=self.comment_var, width=25).grid(row=2, column=1, pady=2)
+
+        ttk.Label(form, text="Waga:").grid(row=3, column=0, sticky="e", pady=2)
+        self.weight_var = tk.StringVar()
+        ttk.Entry(
+            form,
+            textvariable=self.weight_var,
+            width=25,
+            validate="key",
+            validatecommand=(self.register(self.validate_number), "%P"),
+        ).grid(row=3, column=1, pady=2)
+
+        ttk.Label(form, text="Typ:").grid(row=4, column=0, sticky="e", pady=2)
+        self.type_var = tk.StringVar()
+        ttk.Entry(form, textvariable=self.type_var, width=25).grid(row=4, column=1, pady=2)
+
+        ttk.Label(form, text="Dostawca:").grid(row=5, column=0, sticky="e", pady=2)
+        self.supplier_var = tk.StringVar()
+        ttk.Entry(form, textvariable=self.supplier_var, width=25).grid(row=5, column=1, pady=2)
+
+        btn_frame = ttk.Frame(form)
+        btn_frame.grid(row=6, column=0, columnspan=2, pady=5)
+        ttk.Button(btn_frame, text="Dodaj / Aktualizuj", command=self.add_update).pack(side=tk.LEFT, padx=2)
+        ttk.Button(btn_frame, text="Usuń", command=self.delete_item).pack(side=tk.LEFT, padx=2)
+        ttk.Button(btn_frame, text="Zapisz", command=self.save).pack(side=tk.LEFT, padx=2)
+
+        self.refresh_list()
+
+    def refresh_list(self):
+        self.listbox.delete(0, tk.END)
+        for mat in self.materials:
+            self.listbox.insert(tk.END, mat.get("name", ""))
+
+    def on_select(self, event):
+        if not self.listbox.curselection():
+            self.selected_index = None
+            self.name_var.set("")
+            self.qty_var.set("")
+            self.comment_var.set("")
+            self.weight_var.set("")
+            self.type_var.set("")
+            self.supplier_var.set("")
+            return
+        idx = self.listbox.curselection()[0]
+        self.selected_index = idx
+        mat = self.materials[idx]
+        self.name_var.set(mat.get("name", ""))
+        self.qty_var.set(mat.get("quantity", ""))
+        self.comment_var.set(mat.get("comment", ""))
+        self.weight_var.set(mat.get("weight", ""))
+        self.type_var.set(mat.get("type", ""))
+        self.supplier_var.set(mat.get("supplier", ""))
+
+    def add_update(self):
+        data = {
+            "name": self.name_var.get(),
+            "quantity": self.qty_var.get(),
+            "comment": self.comment_var.get(),
+            "weight": self.weight_var.get(),
+            "type": self.type_var.get(),
+            "supplier": self.supplier_var.get(),
+        }
+        if self.selected_index is None:
+            self.materials.append(data)
+        else:
+            self.materials[self.selected_index] = data
+        self.refresh_list()
+
+    def delete_item(self):
+        if self.selected_index is not None:
+            del self.materials[self.selected_index]
+            self.selected_index = None
+            self.refresh_list()
+
+    def save(self):
+        try:
+            save_auxiliary_materials(self.materials)
+            messagebox.showinfo("Zapis", "Zapisano dane do pliku.")
+        except Exception as e:
+            messagebox.showerror("Błąd", str(e))
+
+    def validate_number(self, value: str) -> bool:
+        if value == "":
+            return True
+        value = value.replace(",", ".")
+        try:
+            return float(value) >= 0
+        except ValueError:
+            return False
+

--- a/packing_app/gui/tab_direct_packaging.py
+++ b/packing_app/gui/tab_direct_packaging.py
@@ -1,0 +1,130 @@
+import tkinter as tk
+from tkinter import ttk, messagebox
+
+from core.utils import load_direct_packaging, save_direct_packaging
+
+
+class TabDirectPackaging(ttk.Frame):
+    """Editor for direct packaging materials."""
+
+    def __init__(self, parent):
+        super().__init__(parent)
+        self.materials = load_direct_packaging()
+        self.selected_index = None
+        self.build_ui()
+
+    def build_ui(self):
+        list_frame = ttk.Frame(self)
+        list_frame.pack(side=tk.LEFT, fill=tk.BOTH, expand=True, padx=5, pady=5)
+
+        self.listbox = tk.Listbox(list_frame, height=15)
+        self.listbox.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        self.listbox.bind("<<ListboxSelect>>", self.on_select)
+
+        scrollbar = ttk.Scrollbar(list_frame, orient="vertical", command=self.listbox.yview)
+        scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
+        self.listbox.config(yscrollcommand=scrollbar.set)
+
+        form = ttk.Frame(self)
+        form.pack(side=tk.LEFT, fill=tk.Y, padx=10, pady=5)
+
+        ttk.Label(form, text="Nazwa:").grid(row=0, column=0, sticky="e", pady=2)
+        self.name_var = tk.StringVar()
+        ttk.Entry(form, textvariable=self.name_var, width=25).grid(row=0, column=1, pady=2)
+
+        ttk.Label(form, text="Ilość/Jednostka:").grid(row=1, column=0, sticky="e", pady=2)
+        self.qty_var = tk.StringVar()
+        ttk.Entry(form, textvariable=self.qty_var, width=25).grid(row=1, column=1, pady=2)
+
+        ttk.Label(form, text="Komentarz:").grid(row=2, column=0, sticky="e", pady=2)
+        self.comment_var = tk.StringVar()
+        ttk.Entry(form, textvariable=self.comment_var, width=25).grid(row=2, column=1, pady=2)
+
+        ttk.Label(form, text="Waga:").grid(row=3, column=0, sticky="e", pady=2)
+        self.weight_var = tk.StringVar()
+        ttk.Entry(
+            form,
+            textvariable=self.weight_var,
+            width=25,
+            validate="key",
+            validatecommand=(self.register(self.validate_number), "%P"),
+        ).grid(row=3, column=1, pady=2)
+
+        ttk.Label(form, text="Typ:").grid(row=4, column=0, sticky="e", pady=2)
+        self.type_var = tk.StringVar()
+        ttk.Entry(form, textvariable=self.type_var, width=25).grid(row=4, column=1, pady=2)
+
+        ttk.Label(form, text="Dostawca:").grid(row=5, column=0, sticky="e", pady=2)
+        self.supplier_var = tk.StringVar()
+        ttk.Entry(form, textvariable=self.supplier_var, width=25).grid(row=5, column=1, pady=2)
+
+        btn_frame = ttk.Frame(form)
+        btn_frame.grid(row=6, column=0, columnspan=2, pady=5)
+        ttk.Button(btn_frame, text="Dodaj / Aktualizuj", command=self.add_update).pack(side=tk.LEFT, padx=2)
+        ttk.Button(btn_frame, text="Usuń", command=self.delete_item).pack(side=tk.LEFT, padx=2)
+        ttk.Button(btn_frame, text="Zapisz", command=self.save).pack(side=tk.LEFT, padx=2)
+
+        self.refresh_list()
+
+    def refresh_list(self):
+        self.listbox.delete(0, tk.END)
+        for mat in self.materials:
+            self.listbox.insert(tk.END, mat.get("name", ""))
+
+    def on_select(self, event):
+        if not self.listbox.curselection():
+            self.selected_index = None
+            self.name_var.set("")
+            self.qty_var.set("")
+            self.comment_var.set("")
+            self.weight_var.set("")
+            self.type_var.set("")
+            self.supplier_var.set("")
+            return
+        idx = self.listbox.curselection()[0]
+        self.selected_index = idx
+        mat = self.materials[idx]
+        self.name_var.set(mat.get("name", ""))
+        self.qty_var.set(mat.get("quantity", ""))
+        self.comment_var.set(mat.get("comment", ""))
+        self.weight_var.set(mat.get("weight", ""))
+        self.type_var.set(mat.get("type", ""))
+        self.supplier_var.set(mat.get("supplier", ""))
+
+    def add_update(self):
+        data = {
+            "name": self.name_var.get(),
+            "quantity": self.qty_var.get(),
+            "comment": self.comment_var.get(),
+            "weight": self.weight_var.get(),
+            "type": self.type_var.get(),
+            "supplier": self.supplier_var.get(),
+        }
+        if self.selected_index is None:
+            self.materials.append(data)
+        else:
+            self.materials[self.selected_index] = data
+        self.refresh_list()
+
+    def delete_item(self):
+        if self.selected_index is not None:
+            del self.materials[self.selected_index]
+            self.selected_index = None
+            self.refresh_list()
+
+    def save(self):
+        try:
+            save_direct_packaging(self.materials)
+            messagebox.showinfo("Zapis", "Zapisano dane do pliku.")
+        except Exception as e:
+            messagebox.showerror("Błąd", str(e))
+
+    def validate_number(self, value: str) -> bool:
+        if value == "":
+            return True
+        value = value.replace(",", ".")
+        try:
+            return float(value) >= 0
+        except ValueError:
+            return False
+

--- a/packing_app/gui/tab_indirect_packaging.py
+++ b/packing_app/gui/tab_indirect_packaging.py
@@ -1,0 +1,130 @@
+import tkinter as tk
+from tkinter import ttk, messagebox
+
+from core.utils import load_indirect_packaging, save_indirect_packaging
+
+
+class TabIndirectPackaging(ttk.Frame):
+    """Editor for indirect packaging materials."""
+
+    def __init__(self, parent):
+        super().__init__(parent)
+        self.materials = load_indirect_packaging()
+        self.selected_index = None
+        self.build_ui()
+
+    def build_ui(self):
+        list_frame = ttk.Frame(self)
+        list_frame.pack(side=tk.LEFT, fill=tk.BOTH, expand=True, padx=5, pady=5)
+
+        self.listbox = tk.Listbox(list_frame, height=15)
+        self.listbox.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        self.listbox.bind("<<ListboxSelect>>", self.on_select)
+
+        scrollbar = ttk.Scrollbar(list_frame, orient="vertical", command=self.listbox.yview)
+        scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
+        self.listbox.config(yscrollcommand=scrollbar.set)
+
+        form = ttk.Frame(self)
+        form.pack(side=tk.LEFT, fill=tk.Y, padx=10, pady=5)
+
+        ttk.Label(form, text="Nazwa:").grid(row=0, column=0, sticky="e", pady=2)
+        self.name_var = tk.StringVar()
+        ttk.Entry(form, textvariable=self.name_var, width=25).grid(row=0, column=1, pady=2)
+
+        ttk.Label(form, text="Ilość/Jednostka:").grid(row=1, column=0, sticky="e", pady=2)
+        self.qty_var = tk.StringVar()
+        ttk.Entry(form, textvariable=self.qty_var, width=25).grid(row=1, column=1, pady=2)
+
+        ttk.Label(form, text="Komentarz:").grid(row=2, column=0, sticky="e", pady=2)
+        self.comment_var = tk.StringVar()
+        ttk.Entry(form, textvariable=self.comment_var, width=25).grid(row=2, column=1, pady=2)
+
+        ttk.Label(form, text="Waga:").grid(row=3, column=0, sticky="e", pady=2)
+        self.weight_var = tk.StringVar()
+        ttk.Entry(
+            form,
+            textvariable=self.weight_var,
+            width=25,
+            validate="key",
+            validatecommand=(self.register(self.validate_number), "%P"),
+        ).grid(row=3, column=1, pady=2)
+
+        ttk.Label(form, text="Typ:").grid(row=4, column=0, sticky="e", pady=2)
+        self.type_var = tk.StringVar()
+        ttk.Entry(form, textvariable=self.type_var, width=25).grid(row=4, column=1, pady=2)
+
+        ttk.Label(form, text="Dostawca:").grid(row=5, column=0, sticky="e", pady=2)
+        self.supplier_var = tk.StringVar()
+        ttk.Entry(form, textvariable=self.supplier_var, width=25).grid(row=5, column=1, pady=2)
+
+        btn_frame = ttk.Frame(form)
+        btn_frame.grid(row=6, column=0, columnspan=2, pady=5)
+        ttk.Button(btn_frame, text="Dodaj / Aktualizuj", command=self.add_update).pack(side=tk.LEFT, padx=2)
+        ttk.Button(btn_frame, text="Usuń", command=self.delete_item).pack(side=tk.LEFT, padx=2)
+        ttk.Button(btn_frame, text="Zapisz", command=self.save).pack(side=tk.LEFT, padx=2)
+
+        self.refresh_list()
+
+    def refresh_list(self):
+        self.listbox.delete(0, tk.END)
+        for mat in self.materials:
+            self.listbox.insert(tk.END, mat.get("name", ""))
+
+    def on_select(self, event):
+        if not self.listbox.curselection():
+            self.selected_index = None
+            self.name_var.set("")
+            self.qty_var.set("")
+            self.comment_var.set("")
+            self.weight_var.set("")
+            self.type_var.set("")
+            self.supplier_var.set("")
+            return
+        idx = self.listbox.curselection()[0]
+        self.selected_index = idx
+        mat = self.materials[idx]
+        self.name_var.set(mat.get("name", ""))
+        self.qty_var.set(mat.get("quantity", ""))
+        self.comment_var.set(mat.get("comment", ""))
+        self.weight_var.set(mat.get("weight", ""))
+        self.type_var.set(mat.get("type", ""))
+        self.supplier_var.set(mat.get("supplier", ""))
+
+    def add_update(self):
+        data = {
+            "name": self.name_var.get(),
+            "quantity": self.qty_var.get(),
+            "comment": self.comment_var.get(),
+            "weight": self.weight_var.get(),
+            "type": self.type_var.get(),
+            "supplier": self.supplier_var.get(),
+        }
+        if self.selected_index is None:
+            self.materials.append(data)
+        else:
+            self.materials[self.selected_index] = data
+        self.refresh_list()
+
+    def delete_item(self):
+        if self.selected_index is not None:
+            del self.materials[self.selected_index]
+            self.selected_index = None
+            self.refresh_list()
+
+    def save(self):
+        try:
+            save_indirect_packaging(self.materials)
+            messagebox.showinfo("Zapis", "Zapisano dane do pliku.")
+        except Exception as e:
+            messagebox.showerror("Błąd", str(e))
+
+    def validate_number(self, value: str) -> bool:
+        if value == "":
+            return True
+        value = value.replace(",", ".")
+        try:
+            return float(value) >= 0
+        except ValueError:
+            return False
+


### PR DESCRIPTION
## Summary
- introduce generic XML loader/saver helpers
- add direct, indirect and auxiliary materials data files
- implement GUI tabs for direct packaging, indirect packaging and auxiliary materials
- extend main window with new tabs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684814f21af48325ba68197291ad7bac