### PR TITLE
Improve layer sync handling

### DIFF
--- a/packing_app/gui/tab_pallet.py
+++ b/packing_app/gui/tab_pallet.py
@@ -42,6 +42,7 @@ class TabPallet(ttk.Frame):
         self.pack(fill=tk.BOTH, expand=True)
         self.layouts = []
         self.layers = []
+        self.layer_patterns = []
         self.slip_sheet_layers = []
         self.transformations = []
         self.products_per_carton = 1
@@ -415,6 +416,7 @@ class TabPallet(ttk.Frame):
     def update_layers(self, *args):
         num_layers = getattr(self, "num_layers", int(parse_dim(self.num_layers_var)))
         self.layers = []
+        self.layer_patterns = []
         self.transformations = []
         odd_name = self.odd_layout_var.get()
         even_name = self.even_layout_var.get()
@@ -434,10 +436,13 @@ class TabPallet(ttk.Frame):
             if i % 2 == 1:
                 self.layers.append(odd_layout)
                 transform = self.odd_transform_var.get()
+                patt = odd_name
             else:
                 self.layers.append(even_layout)
                 transform = self.even_transform_var.get()
+                patt = even_name
             self.transformations.append(transform)
+            self.layer_patterns.append(patt)
         self.draw_pallet()
 
     def on_pallet_selected(self, *args):
@@ -922,7 +927,12 @@ class TabPallet(ttk.Frame):
         )
         self.layers[layer_idx][idx] = (snap_x, snap_y, w, h)
         other_layer = 1 - layer_idx
-        if other_layer < len(self.layers) and idx < len(self.layers[other_layer]):
+        if (
+            other_layer < len(self.layers)
+            and idx < len(self.layers[other_layer])
+            and self.layer_patterns[other_layer] == self.layer_patterns[layer_idx]
+            and self.transformations[other_layer] == self.transformations[layer_idx]
+        ):
             self.layers[other_layer][idx] = (snap_x, snap_y, w, h)
         self.selected_patch = None
         self.draw_pallet()
@@ -938,7 +948,11 @@ class TabPallet(ttk.Frame):
             h = parse_dim(self.box_l_var) + 2 * thickness
         self.layers[layer_idx].append((pos[0], pos[1], w, h))
         other_layer = 1 - layer_idx
-        if other_layer < len(self.layers):
+        if (
+            other_layer < len(self.layers)
+            and self.layer_patterns[other_layer] == self.layer_patterns[layer_idx]
+            and self.transformations[other_layer] == self.transformations[layer_idx]
+        ):
             self.layers[other_layer].append((pos[0], pos[1], w, h))
         self.draw_pallet()
         self.update_summary()
@@ -951,7 +965,12 @@ class TabPallet(ttk.Frame):
             layer_idx, idx, _ = self.selected_patch
             del self.layers[layer_idx][idx]
             other_layer = 1 - layer_idx
-            if other_layer < len(self.layers) and idx < len(self.layers[other_layer]):
+            if (
+                other_layer < len(self.layers)
+                and idx < len(self.layers[other_layer])
+                and self.layer_patterns[other_layer] == self.layer_patterns[layer_idx]
+                and self.transformations[other_layer] == self.transformations[layer_idx]
+            ):
                 del self.layers[other_layer][idx]
             self.selected_patch = None
             self.draw_pallet()

--- a/tests/test_gui_sync.py
+++ b/tests/test_gui_sync.py
@@ -20,6 +20,7 @@ def make_dummy():
     d.box_w_var = var(10)
     d.box_l_var = var(10)
     d.transformations = ["Brak", "Brak"]
+    d.layer_patterns = ["A", "A"]
     d.layers = [[(0, 0, 10, 10)], [(0, 0, 10, 10)]]
     d.snap_position = lambda x, y, w, h, pw, pl, other: (x, y)
     d.inverse_transformation = lambda pos, trans, pw, pl, bw, bl: pos
@@ -42,6 +43,21 @@ def test_insert_and_delete_sync():
     assert len(dummy.layers[1]) == 2
     assert dummy.layers[0][-1][:2] == (10, 10)
     assert dummy.layers[1][-1][:2] == (10, 10)
+    dummy.selected_patch = (0, 0, DummyPatch())
+    TabPallet.delete_selected_carton(dummy)
+    assert len(dummy.layers[0]) == 1
+    assert len(dummy.layers[1]) == 1
+
+def test_no_cross_sync_when_patterns_differ():
+    dummy = make_dummy()
+    dummy.layer_patterns = ["A", "B"]
+    dummy.selected_patch = (0, 0, DummyPatch(2, 2))
+    TabPallet.on_release(dummy, None)
+    assert dummy.layers[0][0][:2] == (2, 2)
+    assert dummy.layers[1][0][:2] == (0, 0)
+    TabPallet.insert_carton(dummy, 0, (5, 5))
+    assert len(dummy.layers[0]) == 2
+    assert len(dummy.layers[1]) == 1
     dummy.selected_patch = (0, 0, DummyPatch())
     TabPallet.delete_selected_carton(dummy)
     assert len(dummy.layers[0]) == 1


### PR DESCRIPTION
## Summary
- track selected pattern per layer
- sync carton edits only if patterns and transforms match
- test that mixed patterns do not cross-sync

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684820755dec8325ba6407624b8e4318