### PR TITLE
Fix lint errors

### DIFF
--- a/palletizer_core/selector.py
+++ b/palletizer_core/selector.py
@@ -164,7 +164,7 @@ class PatternSelector:
         # to the fraction of their area that is unsupported.
         if pattern:
             com_x = sum(x + w / 2 for x, _, w, _ in pattern) / len(pattern)
-            com_y = sum(y + l / 2 for _, y, _, l in pattern) / len(pattern)
+            com_y = sum(y + length / 2 for _, y, _, length in pattern) / len(pattern)
             center_x = self.pallet.width / 2
             center_y = self.pallet.length / 2
             dist = ((com_x - center_x) ** 2 + (com_y - center_y) ** 2) ** 0.5
@@ -172,9 +172,9 @@ class PatternSelector:
             com_factor = max(0.0, 1 - dist / max_dist)
 
             total_inside = 0.0
-            for x, y, w, l in pattern:
+            for x, y, w, length in pattern:
                 overlap_w = max(0.0, min(x + w, self.pallet.width) - max(x, 0.0))
-                overlap_l = max(0.0, min(y + l, self.pallet.length) - max(y, 0.0))
+                overlap_l = max(0.0, min(y + length, self.pallet.length) - max(y, 0.0))
                 total_inside += overlap_w * overlap_l
             support_fraction = total_inside / (len(pattern) * box_area)
 

--- a/palletizer_core/sequencer.py
+++ b/palletizer_core/sequencer.py
@@ -44,7 +44,7 @@ class EvenOddSequencer:
         min_x = min(x for x, _, _, _ in self.pattern)
         max_x = max(x + w for x, _, w, _ in self.pattern)
         min_y = min(y for _, y, _, _ in self.pattern)
-        max_y = max(y + l for _, y, _, l in self.pattern)
+        max_y = max(y + length for _, y, _, length in self.pattern)
 
         left = min_x
         right = self.pallet.width - max_x

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -1,5 +1,3 @@
-import pytest
-
 from packing_app.core.algorithms import maximize_mixed_layout, pack_pinwheel
 
 
@@ -23,9 +21,9 @@ def test_pinwheel_layout_fits_and_no_collisions():
     box_w, box_l = 250, 150
     _, positions = pack_pinwheel(pallet_w, pallet_l, box_w, box_l)
 
-    for x, y, w, l in positions:
+    for x, y, w, length in positions:
         assert 0 <= x <= pallet_w - w
-        assert 0 <= y <= pallet_l - l
+        assert 0 <= y <= pallet_l - length
 
     for i, pos in enumerate(positions):
         for other in positions[i + 1 :]:
@@ -37,9 +35,9 @@ def test_pinwheel_fallback_for_small_area():
     box_w, box_l = 180, 100
     _, positions = pack_pinwheel(pallet_w, pallet_l, box_w, box_l)
 
-    for x, y, w, l in positions:
+    for x, y, w, length in positions:
         assert 0 <= x <= pallet_w - w
-        assert 0 <= y <= pallet_l - l
+        assert 0 <= y <= pallet_l - length
 
     for i, pos in enumerate(positions):
         for other in positions[i + 1 :]:

--- a/tests/test_interlock_default.py
+++ b/tests/test_interlock_default.py
@@ -1,9 +1,4 @@
-import sys
 import types
-from pathlib import Path
-
-ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT))
 
 from palletizer_core import Carton, Pallet, PatternSelector
 from packing_app.gui.tab_pallet import TabPallet

--- a/tests/test_palletizer_core.py
+++ b/tests/test_palletizer_core.py
@@ -46,7 +46,7 @@ def test_even_odd_sequencer_shift():
     seq = EvenOddSequencer(pattern, carton, pallet)
     even, odd = seq.best_shift()
 
-    shifted = [(x + carton.width / 2, y, w, l) for x, y, w, l in even]
+    shifted = [(x + carton.width / 2, y, w, length) for x, y, w, length in even]
     assert odd == shifted
 
 

--- a/tests/test_sequencer.py
+++ b/tests/test_sequencer.py
@@ -1,8 +1,4 @@
-import os
-import sys
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from palletizer_core.models import Carton, Pallet
 from palletizer_core.sequencer import EvenOddSequencer


### PR DESCRIPTION
## Summary
- ensure tests and core modules use clearer variable names
- clean up imports and sys.path editing in unit tests

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68482595f7e08325b0a7db3ad633e960