### PR TITLE
Drop unused box dimension args from transformations

### DIFF
--- a/packing_app/gui/tab_pallet.py
+++ b/packing_app/gui/tab_pallet.py
@@ -456,9 +456,7 @@ class TabPallet(ttk.Frame):
         self.box_h_var.set(str(dims[2]))
         self.compute_pallet()
 
-    def apply_transformation(
-        self, positions, transform, pallet_w, pallet_l, box_w, box_l
-    ):
+    def apply_transformation(self, positions, transform, pallet_w, pallet_l):
         new_positions = []
         for x, y, w, h in positions:
             if transform == "Brak":
@@ -481,9 +479,7 @@ class TabPallet(ttk.Frame):
                 new_positions.append((new_x, new_y, w, h))
         return new_positions
 
-    def inverse_transformation(
-        self, positions, transform, pallet_w, pallet_l, box_w, box_l
-    ):
+    def inverse_transformation(self, positions, transform, pallet_w, pallet_l):
         """Reverse the transformation applied to the positions."""
         new_positions = []
         for x, y, w, h in positions:
@@ -494,8 +490,6 @@ class TabPallet(ttk.Frame):
                     transform,
                     pallet_w,
                     pallet_l,
-                    box_w,
-                    box_l,
                 )
             )
         return new_positions
@@ -779,10 +773,6 @@ class TabPallet(ttk.Frame):
                     self.transformations[idx],
                     pallet_w,
                     pallet_l,
-                    parse_dim(self.box_w_var)
-                    + 2 * parse_dim(self.cardboard_thickness_var),
-                    parse_dim(self.box_l_var)
-                    + 2 * parse_dim(self.cardboard_thickness_var),
                 )
                 collision_idx = self.detect_collisions(coords, pallet_w, pallet_l)
                 for i, (x, y, w, h) in enumerate(coords):
@@ -869,16 +859,12 @@ class TabPallet(ttk.Frame):
         x, y, w, h = self.layers[layer_idx][idx]
         pallet_w = parse_dim(self.pallet_w_var)
         pallet_l = parse_dim(self.pallet_l_var)
-        thickness = parse_dim(self.cardboard_thickness_var)
-        box_w_ext = parse_dim(self.box_w_var) + 2 * thickness
-        box_l_ext = parse_dim(self.box_l_var) + 2 * thickness
+
         orig_x, orig_y, _, _ = self.inverse_transformation(
             [(new_x, new_y, w, h)],
             self.transformations[layer_idx],
             pallet_w,
             pallet_l,
-            box_w_ext,
-            box_l_ext,
         )[0]
         self.layers[layer_idx][idx] = (orig_x, orig_y, w, h)
         coords = self.apply_transformation(
@@ -886,8 +872,6 @@ class TabPallet(ttk.Frame):
             self.transformations[layer_idx],
             pallet_w,
             pallet_l,
-            box_w_ext,
-            box_l_ext,
         )
         collision_idx = self.detect_collisions(coords, pallet_w, pallet_l)
         for p, i in self.patches[layer_idx]:
@@ -905,16 +889,12 @@ class TabPallet(ttk.Frame):
         x, y, w, h = self.layers[layer_idx][idx]
         pallet_w = parse_dim(self.pallet_w_var)
         pallet_l = parse_dim(self.pallet_l_var)
-        thickness = parse_dim(self.cardboard_thickness_var)
-        box_w_ext = parse_dim(self.box_w_var) + 2 * thickness
-        box_l_ext = parse_dim(self.box_l_var) + 2 * thickness
+
         orig_x, orig_y, _, _ = self.inverse_transformation(
             [(new_x, new_y, w, h)],
             self.transformations[layer_idx],
             pallet_w,
             pallet_l,
-            box_w_ext,
-            box_l_ext,
         )[0]
         other_boxes = [b for i, b in enumerate(self.layers[layer_idx]) if i != idx]
         snap_x, snap_y = self.snap_position(

--- a/tests/test_gui_sync.py
+++ b/tests/test_gui_sync.py
@@ -22,7 +22,7 @@ def make_dummy():
     d.transformations = ["Brak", "Brak"]
     d.layers = [[(0, 0, 10, 10)], [(0, 0, 10, 10)]]
     d.snap_position = lambda x, y, w, h, pw, pl, other: (x, y)
-    d.inverse_transformation = lambda pos, trans, pw, pl, bw, bl: pos
+    d.inverse_transformation = lambda pos, trans, pw, pl: pos
     d.draw_pallet = lambda: None
     d.update_summary = lambda: None
     d.selected_patch = None

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -11,8 +11,6 @@ def test_mirror_inverse():
         "Odbicie wzdłuż dłuższego boku",
         pallet_w,
         pallet_l,
-        30.0,
-        40.0,
     )
     reverted = TabPallet.inverse_transformation(
         dummy,
@@ -20,7 +18,5 @@ def test_mirror_inverse():
         "Odbicie wzdłuż dłuższego boku",
         pallet_w,
         pallet_l,
-        30.0,
-        40.0,
     )
     assert reverted == positions


### PR DESCRIPTION
## Summary
- clean up transformation helpers by removing unused box dimensions
- adapt TabPallet calls to new signatures
- remove leftover local variables in GUI event handlers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68482064cbfc8325b780249feea1a5f8