### PR TITLE
Add slip sheet handling

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -174,3 +174,29 @@ def save_cartons(cartons: list) -> None:
     load_cartons.cache_clear()
     load_cartons_with_weights.cache_clear()
 
+
+def load_slip_sheets() -> list:
+    """Load slip sheet definitions from slip_sheets.xml."""
+    path = os.path.join(DATA_DIR, "slip_sheets.xml")
+    if not os.path.exists(path):
+        return []
+    root = _load_xml(path)
+    sheets = []
+    for sheet in root.findall("sheet"):
+        weight = sheet.get("weight", "0")
+        try:
+            weight = float(weight)
+        except ValueError:
+            weight = 0.0
+        sheets.append({"weight": weight})
+    return sheets
+
+
+def save_slip_sheets(sheets: list) -> None:
+    """Save slip sheet definitions back to slip_sheets.xml."""
+    root = ET.Element("slip_sheets")
+    for sheet in sheets:
+        ET.SubElement(root, "sheet", weight=str(sheet.get("weight", "")))
+    tree = ET.ElementTree(root)
+    tree.write(os.path.join(DATA_DIR, "slip_sheets.xml"), encoding="utf-8", xml_declaration=True)
+

--- a/packing_app/data/slip_sheets.xml
+++ b/packing_app/data/slip_sheets.xml
@@ -1,0 +1,4 @@
+<slip_sheets>
+    <sheet weight="0.2" />
+    <sheet weight="0.4" />
+</slip_sheets>


### PR DESCRIPTION
## Summary
- allow specifying slip sheet count not thickness
- load slip sheet weights from XML and provide dropdown
- ignore slip sheet thickness in height and compute weight using count
- add slip sheet XML data and utilities

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684814f0bbac83258d7ad447fd44a936