### PR TITLE
Handle slip sheet counts

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -243,3 +243,29 @@ def save_auxiliary_materials(materials: list) -> None:
     """Save auxiliary materials to auxiliary_materials.xml."""
     _save_generic_materials('auxiliary_materials.xml', materials)
 
+
+@lru_cache(maxsize=None)
+def load_slip_sheets() -> list:
+    """Load slip sheet weights from slip_sheets.xml."""
+    path = os.path.join(DATA_DIR, 'slip_sheets.xml')
+    if not os.path.exists(path):
+        return []
+    root = _load_xml(path)
+    weights = []
+    for slip in root.findall('slip'):
+        try:
+            weights.append(float(slip.get('weight', '0')))
+        except (TypeError, ValueError) as e:
+            raise ValueError(f"Niepoprawne dane przekładki '{slip.attrib}': {e}")
+    return weights
+
+
+def save_slip_sheets(weights: list) -> None:
+    """Save slip sheet weights to slip_sheets.xml."""
+    root = ET.Element('slip_sheets')
+    for w in weights:
+        ET.SubElement(root, 'slip', weight=str(w))
+    tree = ET.ElementTree(root)
+    tree.write(os.path.join(DATA_DIR, 'slip_sheets.xml'), encoding='utf-8', xml_declaration=True)
+    load_slip_sheets.cache_clear()
+

--- a/packing_app/data/slip_sheets.xml
+++ b/packing_app/data/slip_sheets.xml
@@ -1,0 +1,3 @@
+<slip_sheets>
+  <slip weight="0.5"/>
+</slip_sheets>

--- a/packing_app/gui/tab_pallet.py
+++ b/packing_app/gui/tab_pallet.py
@@ -17,6 +17,7 @@ from core.utils import (
     load_cartons_with_weights,
     load_pallets_with_weights,
     load_materials,
+    load_slip_sheets,
 )
 
 
@@ -39,11 +40,12 @@ class TabPallet(ttk.Frame):
             p["name"]: p["weight"] for p in load_pallets_with_weights()
         }
         self.material_weights = load_materials()
+        slips = load_slip_sheets()
+        self.slip_sheet_weight = slips[0] if slips else 0
         self.pack(fill=tk.BOTH, expand=True)
         self.layouts = []
         self.layers = []
         self.layer_patterns = []
-        self.slip_sheet_layers = []
         self.transformations = []
         self.products_per_carton = 1
         self.tape_per_carton = 0.0
@@ -240,33 +242,19 @@ class TabPallet(ttk.Frame):
             command=self.compute_pallet,
         ).grid(row=0, column=6, padx=5, pady=5, sticky="w")
 
-        ttk.Label(layers_frame, text="Grubość przekładki (mm):").grid(
+        ttk.Label(layers_frame, text="Liczba przekładek:").grid(
             row=2, column=0, padx=5, pady=5
         )
-        self.slip_thickness_var = tk.StringVar(value="0")
-        entry_slip_thickness = ttk.Entry(
+        self.slip_count_var = tk.StringVar(value="0")
+        entry_slip_count = ttk.Entry(
             layers_frame,
-            textvariable=self.slip_thickness_var,
+            textvariable=self.slip_count_var,
             width=5,
             validate="key",
             validatecommand=(self.register(self.validate_number), "%P"),
         )
-        entry_slip_thickness.grid(row=2, column=1, padx=5, pady=5)
-        entry_slip_thickness.bind("<Return>", self.compute_pallet)
-
-        ttk.Label(layers_frame, text="Waga przekładki (kg):").grid(
-            row=2, column=2, padx=5, pady=5
-        )
-        self.slip_weight_var = tk.StringVar(value="0")
-        entry_slip_weight = ttk.Entry(
-            layers_frame,
-            textvariable=self.slip_weight_var,
-            width=5,
-            validate="key",
-            validatecommand=(self.register(self.validate_number), "%P"),
-        )
-        entry_slip_weight.grid(row=2, column=3, padx=5, pady=5)
-        entry_slip_weight.bind("<Return>", self.compute_pallet)
+        entry_slip_count.grid(row=2, column=1, padx=5, pady=5)
+        entry_slip_count.bind("<Return>", self.compute_pallet)
 
         self.transform_frame = ttk.Frame(layers_frame)
         self.transform_frame.grid(row=3, column=0, columnspan=7, padx=5, pady=5)
@@ -674,7 +662,7 @@ class TabPallet(ttk.Frame):
             box_l = parse_dim(self.box_l_var)
             box_h = parse_dim(self.box_h_var)
             thickness = parse_dim(self.cardboard_thickness_var)
-            slip_thickness = parse_dim(self.slip_thickness_var)
+            slip_count = int(parse_dim(self.slip_count_var))
             box_w_ext = box_w + 2 * thickness
             box_l_ext = box_l + 2 * thickness
             num_layers = int(parse_dim(self.num_layers_var))
@@ -685,9 +673,9 @@ class TabPallet(ttk.Frame):
                     pallet_h if self.include_pallet_height_var.get() else 0
                 )
                 box_h_ext = box_h + 2 * thickness
-                layer_height = box_h_ext + slip_thickness
+                layer_height = box_h_ext
                 if layer_height > 0:
-                    num_layers = max(int((avail + slip_thickness) // layer_height), 0)
+                    num_layers = max(int(avail // layer_height), 0)
                     self.num_layers_var.set(str(num_layers))
 
             if (
@@ -750,7 +738,7 @@ class TabPallet(ttk.Frame):
             }
             self.update_transform_frame()
             self.num_layers = num_layers
-            self.slip_sheet_layers = list(range(1, num_layers))
+            self.slip_count = slip_count
             self.update_layers()
             self.update_summary()
         finally:
@@ -1043,8 +1031,7 @@ class TabPallet(ttk.Frame):
         box_l = parse_dim(self.box_l_var)
         box_h = parse_dim(self.box_h_var)
         thickness = parse_dim(self.cardboard_thickness_var)
-        slip_thickness = parse_dim(self.slip_thickness_var)
-        slip_weight = parse_dim(self.slip_weight_var)
+        slip_count = int(parse_dim(self.slip_count_var))
 
         num_layers = getattr(self, "num_layers", int(parse_dim(self.num_layers_var)))
         box_h_ext = box_h + 2 * thickness
@@ -1057,8 +1044,8 @@ class TabPallet(ttk.Frame):
             for i in range(1, num_layers + 1)
         )
         total_products = total_cartons * self.products_per_carton
-        num_slip = len(self.slip_sheet_layers)
-        stack_height = num_layers * box_h_ext + num_slip * slip_thickness
+        num_slip = getattr(self, "slip_count", slip_count)
+        stack_height = num_layers * box_h_ext
         if self.include_pallet_height_var.get():
             stack_height += pallet_h
 
@@ -1080,6 +1067,6 @@ class TabPallet(ttk.Frame):
         )
         tape_wt = total_tape * self.material_weights.get("tape", 0)
         film_wt = self.film_per_pallet * self.material_weights.get("stretch_film", 0)
-        slip_mass = slip_weight * num_slip
+        slip_mass = self.slip_sheet_weight * num_slip
         total_mass = carton_wt * total_cartons + tape_wt + film_wt + pallet_wt + slip_mass
         self.weight_label.config(text=f"Masa: {total_mass:.2f} kg")


### PR DESCRIPTION
## Summary
- add XML file for slip sheet definitions
- support loading/saving slip sheet data in utils
- replace slip thickness/weight with slip count field in pallet tab
- update pallet calculations to use slip count and stored weight

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68482e529a648325b4c50e6e4494d3df