### PR TITLE
Fix empty compute_interlocked_layout

### DIFF
--- a/packing_app/core/algorithms.py
+++ b/packing_app/core/algorithms.py
@@ -165,7 +165,12 @@ def compute_interlocked_layout(
         If ``True`` (default), even layers (2nd, 4th, ...) are shifted.
         If ``False``, odd layers are shifted instead.
     """
-    count, base_positions = pack_rectangles_mixed_greedy(pallet_w, pallet_l, box_w, box_l)
+    count, base_positions = pack_rectangles_mixed_greedy(
+        pallet_w, pallet_l, box_w, box_l
+    )
+    if not base_positions:
+        empty_layers = [[] for _ in range(num_layers)]
+        return 0, empty_layers, empty_layers
 
     base_layers = [list(base_positions) for _ in range(num_layers)]
 

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -1,4 +1,8 @@
-from packing_app.core.algorithms import maximize_mixed_layout, pack_pinwheel
+from packing_app.core.algorithms import (
+    maximize_mixed_layout,
+    pack_pinwheel,
+    compute_interlocked_layout,
+)
 
 
 def _overlap(a, b):
@@ -42,3 +46,13 @@ def test_pinwheel_fallback_for_small_area():
     for i, pos in enumerate(positions):
         for other in positions[i + 1 :]:
             assert not _overlap(pos, other)
+
+
+def test_compute_interlocked_layout_returns_empty_for_small_pallet():
+    count, base, interlocked = compute_interlocked_layout(
+        pallet_w=100, pallet_l=100, box_w=150, box_l=150
+    )
+
+    assert count == 0
+    assert base == [[] for _ in range(4)]
+    assert interlocked == [[] for _ in range(4)]


### PR DESCRIPTION
## Summary
- avoid min/max on empty lists in `compute_interlocked_layout`
- regression test for small pallet case

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68491fe91714832593768d52a8321ccd