### PR TITLE
Add testing instructions and CI test job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,3 +14,17 @@ jobs:
         run: pip install ruff
       - name: Run ruff
         run: ruff check .
+
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install pytest
+      - name: Run tests
+        run: pytest -q

--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ pause
 ```
 Running this script from Explorer will show any error messages and wait for a key press before closing.
 
+## Testing
+Install the required packages before executing the test suite:
+```bash
+pip install -r requirements.txt
+pytest
+```
+
 ## License
 This project is licensed under the [MIT License](LICENSE).
 


### PR DESCRIPTION
## Summary
- document how to run the test suite
- run tests in CI and install dependencies first

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68492009df588325b134c11ffff7b6e0