### PR TITLE
Fix interlock layout for oversized cartons

### DIFF
--- a/packing_app/core/algorithms.py
+++ b/packing_app/core/algorithms.py
@@ -165,7 +165,12 @@ def compute_interlocked_layout(
         If ``True`` (default), even layers (2nd, 4th, ...) are shifted.
         If ``False``, odd layers are shifted instead.
     """
-    count, base_positions = pack_rectangles_mixed_greedy(pallet_w, pallet_l, box_w, box_l)
+    count, base_positions = pack_rectangles_mixed_greedy(
+        pallet_w, pallet_l, box_w, box_l
+    )
+
+    if count == 0:
+        return 0, [], []
 
     base_layers = [list(base_positions) for _ in range(num_layers)]
 

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -1,4 +1,8 @@
-from packing_app.core.algorithms import maximize_mixed_layout, pack_pinwheel
+from packing_app.core.algorithms import (
+    maximize_mixed_layout,
+    pack_pinwheel,
+    compute_interlocked_layout,
+)
 
 
 def _overlap(a, b):
@@ -42,3 +46,12 @@ def test_pinwheel_fallback_for_small_area():
     for i, pos in enumerate(positions):
         for other in positions[i + 1 :]:
             assert not _overlap(pos, other)
+
+
+def test_compute_interlocked_layout_returns_empty_for_large_carton():
+    # Carton dimensions exceed pallet dimensions, so nothing should be placed
+    count, base, interlocked = compute_interlocked_layout(100, 100, 150, 150)
+
+    assert count == 0
+    assert base == []
+    assert interlocked == []


### PR DESCRIPTION
## Summary
- handle empty packing results in `compute_interlocked_layout`
- test interlock layout with carton larger than the pallet

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849200654388325ad760c68d4ee4dfa