### PR TITLE
Fix group actions in Paletyzacja

### DIFF
--- a/packing_app/gui/tab_pallet.py
+++ b/packing_app/gui/tab_pallet.py
@@ -1120,12 +1120,15 @@ class TabPallet(ttk.Frame):
         if event.xdata is not None and event.ydata is not None:
             self.context_pos = (event.xdata, event.ydata)
 
-        # Automatically select the carton under the cursor
+        # Automatically select the carton under the cursor unless it is already
+        # part of the current selection. This allows context menu actions to be
+        # applied to multiple cartons when right-clicking on any of them.
         found = False
         for patch, idx in self.patches[self.context_layer]:
             contains, _ = patch.contains(event)
             if contains:
-                self.selected_indices = {(self.context_layer, idx)}
+                if (self.context_layer, idx) not in self.selected_indices:
+                    self.selected_indices = {(self.context_layer, idx)}
                 found = True
                 break
         if not found:


### PR DESCRIPTION
## Summary
- allow right-click actions to keep multiple selected cartons

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849291d1724832581b9bf34edf6051b