### PR TITLE
Enable pallet pattern export/import in JSON

### DIFF
--- a/packing_app/core/__init__.py
+++ b/packing_app/core/__init__.py
@@ -1,0 +1,6 @@
+
+"""Utility helpers exposed at the package level."""
+
+from .pattern_io import load_pattern, save_pattern, list_patterns
+
+__all__ = ["load_pattern", "save_pattern", "list_patterns"]

--- a/packing_app/core/pattern_io.py
+++ b/packing_app/core/pattern_io.py
@@ -1,0 +1,33 @@
+import json
+import os
+
+PATTERN_DIR = os.path.join(os.path.dirname(__file__), '..', 'data', 'pallet_patterns')
+
+
+def _ensure_dir() -> None:
+    os.makedirs(PATTERN_DIR, exist_ok=True)
+
+
+def pattern_path(name: str) -> str:
+    return os.path.join(PATTERN_DIR, f"{name}.json")
+
+
+def save_pattern(name: str, data: dict) -> None:
+    """Save pattern data under the given name."""
+    _ensure_dir()
+    with open(pattern_path(name), 'w', encoding='utf-8') as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+
+def load_pattern(name: str) -> dict:
+    """Load pattern data by name."""
+    with open(pattern_path(name), 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+def list_patterns() -> list:
+    """Return available pattern names."""
+    _ensure_dir()
+    files = [f[:-5] for f in os.listdir(PATTERN_DIR) if f.endswith('.json')]
+    files.sort()
+    return files

--- a/tests/test_pattern_apply.py
+++ b/tests/test_pattern_apply.py
@@ -1,0 +1,30 @@
+import types
+from packing_app.gui.tab_pallet import TabPallet
+
+
+def dummy_tab():
+    d = types.SimpleNamespace()
+    d.pallet_w_var = types.SimpleNamespace(get=lambda: '100', set=lambda v: None)
+    d.pallet_l_var = types.SimpleNamespace(get=lambda: '120', set=lambda v: None)
+    d.pallet_h_var = types.SimpleNamespace(get=lambda: '150', set=lambda v: None)
+    d.box_w_var = types.SimpleNamespace(get=lambda: '10', set=lambda v: None)
+    d.box_l_var = types.SimpleNamespace(get=lambda: '20', set=lambda v: None)
+    d.box_h_var = types.SimpleNamespace(get=lambda: '30', set=lambda v: None)
+    d.num_layers_var = types.SimpleNamespace(get=lambda: '1', set=lambda v: None)
+    d.layers = [[(0,0,10,20)]]
+    d.num_layers = 1
+    d.layer_patterns = ['']
+    d.transformations = ['Brak']
+    d.draw_pallet = lambda: None
+    d.update_summary = lambda: None
+    return d
+
+
+def test_gather_and_apply_roundtrip(monkeypatch):
+    tab = dummy_tab()
+    data = TabPallet.gather_pattern_data(tab, 'demo')
+    assert data['name'] == 'demo'
+    new = dummy_tab()
+    TabPallet.apply_pattern_data(new, data)
+    assert new.layers == tab.layers
+    assert new.num_layers == 1

--- a/tests/test_pattern_io.py
+++ b/tests/test_pattern_io.py
@@ -1,0 +1,15 @@
+import packing_app.core.pattern_io as pattern_io
+
+
+def test_save_and_load_pattern(tmp_path, monkeypatch):
+    monkeypatch.setattr(pattern_io, "PATTERN_DIR", tmp_path)
+    data = {
+        "name": "demo",
+        "dimensions": {"width": 100, "length": 120, "height": 150},
+        "productDimensions": {"width": 10, "length": 20, "height": 30},
+        "layers": [[[0, 0, 10, 20]]],
+    }
+    pattern_io.save_pattern("demo", data)
+    assert pattern_io.list_patterns() == ["demo"]
+    loaded = pattern_io.load_pattern("demo")
+    assert loaded == data


### PR DESCRIPTION
## Summary
- expose pattern I/O helpers in `packing_app.core`
- support saving and loading pallet layouts in `TabPallet`
- new module `pattern_io` with JSON helpers
- add buttons to the pallet tab for exporting/importing patterns
- test pattern round‑trip and JSON helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bc240fd0c8325a0d55b37c72e957c