### PR TITLE
Add overlay sync and 180 rotation

### DIFF
--- a/tests/test_gui_sync.py
+++ b/tests/test_gui_sync.py
@@ -33,6 +33,7 @@ def make_dummy():
     d.draw_pallet = lambda: None
     d.update_summary = lambda: None
     d.compute_pallet = lambda *a, **k: None
+    d.overlay_var = types.SimpleNamespace(get=lambda: False)
     d.selected_indices = set()
     d.drag_info = None
     d.highlight_selection = lambda: None
@@ -126,3 +127,20 @@ def test_multi_drag_moves_all_selected():
     assert dummy.layers[0][1][:2] == (25,5)
     assert dummy.layers[1][0][:2] == (5,5)
     assert dummy.layers[1][1][:2] == (25,5)
+
+def test_sync_with_overlay_different_transforms():
+    dummy = make_dummy()
+    dummy.overlay_var.get = lambda: True
+    dummy.transformations = ["Brak", "Odbicie wzdłuż dłuższego boku"]
+    dummy.drag_info = (0, 0, DummyPatch(3, 3))
+    dummy.selected_indices = {(0, 0)}
+    TabPallet.on_release(dummy, None)
+    assert dummy.layers[1][0][:2] == (3, 3)
+
+def test_no_sync_without_overlay_diff_transforms():
+    dummy = make_dummy()
+    dummy.transformations = ["Brak", "Odbicie wzdłuż dłuższego boku"]
+    dummy.drag_info = (0, 0, DummyPatch(4, 4))
+    dummy.selected_indices = {(0, 0)}
+    TabPallet.on_release(dummy, None)
+    assert dummy.layers[1][0][:2] == (0, 0)

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -16,3 +16,20 @@ def test_mirror_inverse():
         pallet_l,
     )
     assert reverted == positions
+
+def test_rotate180_inverse():
+    positions = [(5.0, 5.0, 10.0, 20.0)]
+    pallet_w, pallet_l = 40.0, 60.0
+    rotated = TabPallet.apply_transformation(
+        positions,
+        "Obrót 180°",
+        pallet_w,
+        pallet_l,
+    )
+    reverted = TabPallet.inverse_transformation(
+        rotated,
+        "Obrót 180°",
+        pallet_w,
+        pallet_l,
+    )
+    assert reverted == positions


### PR DESCRIPTION
## Summary
- add checkbox to overlay even/odd layers and sync edits
- allow 180° rotation of layers
- update pallet drawing and editing logic for overlay support
- test new transformation and overlay sync behavior

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866743bdfb48325acca2571160de77f