### PR TITLE
Improve pallet numbering and L-pattern packing

### DIFF
--- a/packing_app/core/algorithms.py
+++ b/packing_app/core/algorithms.py
@@ -134,14 +134,14 @@ def pack_pinwheel(width, height, wprod, lprod, margin=0):
 
     # Fill the vertical strip on the right
     if leftover_x > 0:
-        _, right_strip = pack_rectangles_mixed_greedy(
+        _, right_strip = pack_rectangles_mixed_max(
             leftover_x, eff_height, wprod, lprod
         )
         positions.extend((n_x * block_w + x, y, w, h) for x, y, w, h in right_strip)
 
     # Fill the horizontal strip at the top (excluding the right strip area)
     if leftover_y > 0 and n_x * block_w > 0:
-        _, top_strip = pack_rectangles_mixed_greedy(
+        _, top_strip = pack_rectangles_mixed_max(
             n_x * block_w, leftover_y, wprod, lprod
         )
         positions.extend((x, n_y * block_h + y, w, h) for x, y, w, h in top_strip)
@@ -153,7 +153,7 @@ def pack_l_pattern(width, height, wprod, lprod, margin=0):
     """Pack cartons in repeating 2x2 L-shaped blocks.
 
     A single block contains three cartons arranged in an ``L`` shape.
-    Remaining space around the grid is filled using the mixed greedy
+    Remaining space around the grid is filled using a maximising
     algorithm so that cartons never overlap and stay within the pallet
     bounds.
     """
@@ -182,13 +182,13 @@ def pack_l_pattern(width, height, wprod, lprod, margin=0):
     leftover_y = eff_height - n_y * block_h
 
     if leftover_x > 0:
-        _, right_strip = pack_rectangles_mixed_greedy(
+        _, right_strip = pack_rectangles_mixed_max(
             leftover_x, eff_height, wprod, lprod
         )
         positions.extend((n_x * block_w + x, y, w, h) for x, y, w, h in right_strip)
 
     if leftover_y > 0 and n_x * block_w > 0:
-        _, top_strip = pack_rectangles_mixed_greedy(
+        _, top_strip = pack_rectangles_mixed_max(
             n_x * block_w, leftover_y, wprod, lprod
         )
         positions.extend((x, n_y * block_h + y, w, h) for x, y, w, h in top_strip)

--- a/packing_app/gui/tab_pallet.py
+++ b/packing_app/gui/tab_pallet.py
@@ -842,6 +842,7 @@ class TabPallet(ttk.Frame):
             self.num_layers = num_layers
             self.slip_count = slip_count
             self.update_layers()
+            getattr(self, "sort_layers", lambda: None)()
             self.update_summary()
         finally:
             if hasattr(self, "status_var"):
@@ -964,6 +965,23 @@ class TabPallet(ttk.Frame):
                     patch.set_linewidth(1)
         self.canvas.draw_idle()
 
+    def sort_layers(self):
+        """Sort cartons within each layer for consistent numbering."""
+        new_sel = set()
+        for layer_idx, layer in enumerate(self.layers):
+            order = sorted(range(len(layer)), key=lambda i: (layer[i][1], layer[i][0]))
+            if order != list(range(len(layer))):
+                self.layers[layer_idx] = [layer[i] for i in order]
+                mapping = {old_idx: new_idx for new_idx, old_idx in enumerate(order)}
+            else:
+                mapping = {i: i for i in range(len(layer))}
+            for l_idx, idx in self.selected_indices:
+                if l_idx == layer_idx:
+                    new_sel.add((l_idx, mapping.get(idx, idx)))
+                else:
+                    new_sel.add((l_idx, idx))
+        self.selected_indices = new_sel
+        
     def toggle_edit_mode(self):
         if self.modify_mode_var.get():
             if hasattr(self, "status_var"):
@@ -1129,6 +1147,7 @@ class TabPallet(ttk.Frame):
                 self.layers[other_layer][idx] = (snap_x, snap_y, w, h)
 
         self.drag_info = None
+        getattr(self, "sort_layers", lambda: None)()
         self.draw_pallet()
         self.update_summary()
         self.highlight_selection()
@@ -1149,6 +1168,7 @@ class TabPallet(ttk.Frame):
             and self.layers_linked()
         ):
             self.layers[other_layer].append((pos[0], pos[1], w, h))
+        getattr(self, "sort_layers", lambda: None)()
         self.draw_pallet()
         self.update_summary()
 
@@ -1177,6 +1197,7 @@ class TabPallet(ttk.Frame):
 
         self.selected_indices.clear()
         self.drag_info = None
+        getattr(self, "sort_layers", lambda: None)()
         self.draw_pallet()
         self.update_summary()
         self.highlight_selection()
@@ -1206,7 +1227,7 @@ class TabPallet(ttk.Frame):
                 and self.layers_linked()
             ):
                 self.layers[other_layer][idx] = (x, y, w, h)
-
+        getattr(self, "sort_layers", lambda: None)()
         self.draw_pallet()
         self.update_summary()
 
@@ -1256,6 +1277,7 @@ class TabPallet(ttk.Frame):
         start = 0
         end = pallet_w if orientation == "x" else pallet_l
         TabPallet._distribute(self, layer_idx, indices, start, end, orientation)
+        getattr(self, "sort_layers", lambda: None)()
         self.draw_pallet()
         self.update_summary()
 
@@ -1311,9 +1333,9 @@ class TabPallet(ttk.Frame):
             start = bottom
             end = top
         self._distribute(layer_idx, indices, start, end, orientation)
+        getattr(self, "sort_layers", lambda: None)()
         self.draw_pallet()
         self.update_summary()
-        self.highlight_selection()
         self.highlight_selection()
 
     def distribute_selected_between(self):
@@ -1368,6 +1390,7 @@ class TabPallet(ttk.Frame):
             start = bottom
             end = top
         TabPallet._distribute(self, layer_idx, indices, start, end, orientation)
+        getattr(self, "sort_layers", lambda: None)()
         self.draw_pallet()
         self.update_summary()
 


### PR DESCRIPTION
## Summary
- tweak `pack_l_pattern` algorithm to use maximizing fill strategy
- add `sort_layers` helper in pallet tab GUI
- invoke sorting after layout adjustments so carton numbers stay consistent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867d52a9b80832593b34142810ad410