### PR TITLE
Improve carton numbering and dynamic packing

### DIFF
--- a/palletizer_core/selector.py
+++ b/palletizer_core/selector.py
@@ -153,6 +153,12 @@ class PatternSelector:
             )
             patterns["mixed_max"] = dense
 
+        # dynamic layout using a full search
+        _, dynamic = algorithms.pack_rectangles_dynamic(
+            pallet_w, pallet_l, box_w, box_l
+        )
+        patterns["dynamic"] = dynamic
+
         return patterns
 
     def score(self, pattern: Pattern) -> PatternScore:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy
 matplotlib
 pyyaml
+rectpack

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -4,6 +4,7 @@ from packing_app.core.algorithms import (
     pack_pinwheel,
     compute_interlocked_layout,
     pack_rectangles_mixed_max,
+    pack_rectangles_dynamic,
 )
 
 
@@ -117,6 +118,20 @@ def test_pack_rectangles_mixed_max_mixed_orientations():
     count, positions = pack_rectangles_mixed_max(pallet_w, pallet_l, box_w, box_l)
 
     assert count == 3
+    for x, y, w, h in positions:
+        assert 0 <= x <= pallet_w - w
+        assert 0 <= y <= pallet_l - h
+
+    for i, pos in enumerate(positions):
+        for other in positions[i + 1 :]:
+            assert not _overlap(pos, other)
+
+
+def test_pack_rectangles_dynamic_no_collisions():
+    pallet_w, pallet_l = 1000, 800
+    box_w, box_l = 250, 150
+    count, positions = pack_rectangles_dynamic(pallet_w, pallet_l, box_w, box_l)
+    assert count == len(positions)
     for x, y, w, h in positions:
         assert 0 <= x <= pallet_w - w
         assert 0 <= y <= pallet_l - h


### PR DESCRIPTION
## Summary
- add `rectpack` for better dynamic rectangle placement
- implement `pack_rectangles_dynamic` with `rectpack`
- ensure carton IDs renumber sequentially after edits
- maintain numbering when recomputing layers
- adjust GUI tests for new numbering logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867daff947483259f0e81ae4d3fce7d