### PR TITLE
Add WOLNY CP-SAT packing algorithm

### DIFF
--- a/packing_app/core/algorithms.py
+++ b/packing_app/core/algorithms.py
@@ -501,3 +501,131 @@ def pack_rectangles_dynamic(width, height, wprod, lprod, margin=0):
     count, positions = maximize_mixed_layout(width, height, wprod, lprod, margin, [])
     return count, positions
 
+
+def _build_cp_model(W_i, H_i, w_i, h_i, N):
+    """Return (model, vars_) for the CP-SAT solver."""
+    from ortools.sat.python import cp_model
+
+    m = cp_model.CpModel()
+    x = [m.NewIntVar(0, W_i, f"x{i}") for i in range(N)]
+    y = [m.NewIntVar(0, H_i, f"y{i}") for i in range(N)]
+    rot = [m.NewBoolVar(f"rot{i}") for i in range(N)]
+    w_eff = [m.NewIntVar(min(w_i, h_i), max(w_i, h_i), f"w{i}") for i in range(N)]
+    h_eff = [m.NewIntVar(min(w_i, h_i), max(w_i, h_i), f"h{i}") for i in range(N)]
+
+    x_intv, y_intv = [], []
+    for i in range(N):
+        m.Add(w_eff[i] == rot[i] * h_i + (1 - rot[i]) * w_i)
+        m.Add(h_eff[i] == rot[i] * w_i + (1 - rot[i]) * h_i)
+
+        x_end = m.NewIntVar(0, W_i, f"x_end{i}")
+        y_end = m.NewIntVar(0, H_i, f"y_end{i}")
+        m.Add(x_end == x[i] + w_eff[i])
+        m.Add(y_end == y[i] + h_eff[i])
+        m.Add(x_end <= W_i)
+        m.Add(y_end <= H_i)
+
+        x_intv.append(m.NewIntervalVar(x[i], w_eff[i], x_end, f"x_int{i}"))
+        y_intv.append(m.NewIntervalVar(y[i], h_eff[i], y_end, f"y_int{i}"))
+
+    m.AddNoOverlap2D(x_intv, y_intv)
+    return m, (x, y, w_eff, h_eff, rot)
+
+
+def _solution_to_layout(sol, vars_, scale):
+    x, y, w, h, _ = vars_
+    return [
+        (sol.Value(x[i]) / scale,
+         sol.Value(y[i]) / scale,
+         sol.Value(w[i]) / scale,
+         sol.Value(h[i]) / scale)
+        for i in range(len(x))
+    ]
+
+
+def enumerate_packings_wolny(
+    width,
+    height,
+    wprod,
+    lprod,
+    *,
+    want=15,
+    time_first=20,
+    time_each=20,
+):
+    """Enumerate rectangle packings using a CP-SAT search (WOLNY)."""
+    from ortools.sat.python import cp_model
+
+    scale = 1000
+    W_i, H_i = round(width * scale), round(height * scale)
+    w_i, h_i = round(wprod * scale), round(lprod * scale)
+    if min(W_i, H_i, w_i, h_i) <= 0:
+        return []
+
+    area_big = W_i * H_i
+    area_small = w_i * h_i
+    N_target = area_big // area_small
+    if N_target == 0:
+        return []
+
+    for N in range(N_target, 0, -1):
+        model, vars_ = _build_cp_model(W_i, H_i, w_i, h_i, N)
+
+        solver = cp_model.CpSolver()
+        solver.parameters.max_time_in_seconds = time_first
+        status = solver.Solve(model)
+        if status not in (cp_model.OPTIMAL, cp_model.FEASIBLE):
+            continue
+
+        solutions = [_solution_to_layout(solver, vars_, scale)]
+
+        def get_next():
+            nonlocal solutions
+            if len(solutions) >= want:
+                return None
+
+            solver2 = cp_model.CpSolver()
+            solver2.parameters.max_time_in_seconds = time_each
+            solver2.parameters.enumerate_all_solutions = True
+            solver2.parameters.num_search_workers = 8
+
+            class CB(cp_model.CpSolverSolutionCallback):
+                def __init__(self):
+                    super().__init__()
+                    self.found = None
+
+                def on_solution_callback(self):
+                    rects = _solution_to_layout(self, vars_, scale)
+                    if rects not in solutions:
+                        self.found = rects
+                        self.StopSearch()
+
+            cb = CB()
+            solver2.Solve(model, cb)
+            if cb.found:
+                solutions.append(cb.found)
+                return cb.found
+            return None
+
+        return solutions, get_next
+    return []
+
+
+def pack_rectangles_wolny(width, height, wprod, lprod, *, time_limit=1.0):
+    """Return first packing layout from :func:`enumerate_packings_wolny`."""
+    result = enumerate_packings_wolny(
+        width,
+        height,
+        wprod,
+        lprod,
+        want=1,
+        time_first=time_limit,
+        time_each=time_limit,
+    )
+    if not result:
+        return 0, []
+
+    solutions, _ = result if isinstance(result, tuple) else (result, None)
+    layout = solutions[0]
+    return len(layout), [(x, y, w, h) for x, y, w, h in layout]
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy
 matplotlib
 pyyaml
 rectpack
+ortools

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -4,6 +4,7 @@ from packing_app.core.algorithms import (
     compute_interlocked_layout,
     pack_rectangles_mixed_max,
     pack_rectangles_dynamic,
+    pack_rectangles_wolny,
 )
 
 
@@ -103,6 +104,27 @@ def test_pack_rectangles_dynamic_no_collisions():
     pallet_w, pallet_l = 1000, 800
     box_w, box_l = 250, 150
     count, positions = pack_rectangles_dynamic(pallet_w, pallet_l, box_w, box_l)
+    assert count == len(positions)
+    for x, y, w, h in positions:
+        assert 0 <= x <= pallet_w - w
+        assert 0 <= y <= pallet_l - h
+
+    for i, pos in enumerate(positions):
+        for other in positions[i + 1 :]:
+            assert not _overlap(pos, other)
+
+
+def test_pack_rectangles_wolny_no_collisions():
+    pallet_w, pallet_l = 600, 400
+    box_w, box_l = 200, 150
+    count, positions = pack_rectangles_wolny(
+        pallet_w,
+        pallet_l,
+        box_w,
+        box_l,
+        time_limit=0.5,
+    )
+
     assert count == len(positions)
     for x, y, w, h in positions:
         assert 0 <= x <= pallet_w - w


### PR DESCRIPTION
## Summary
- implement CP-SAT based rectangle packing named `WOLNY`
- expose enumeration helper and wrapper for first solution
- test the new algorithm
- add ortools to requirements

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e363b8ddc8325ac331820951119bc