### PR TITLE
Add WOLNY palletizing algorithm with navigation

### DIFF
--- a/palletizer_core/selector.py
+++ b/palletizer_core/selector.py
@@ -153,6 +153,16 @@ class PatternSelector:
         )
         patterns["dynamic"] = dynamic
 
+        # wolny CP-SAT search
+        res = algorithms.enumerate_packings_wolny(
+            pallet_w, pallet_l, box_w, box_l, want=1, time_first=2, time_each=2
+        )
+        if res:
+            sol, _ = res if isinstance(res, tuple) else (res, None)
+            patterns["wolny"] = sol[0]
+        else:
+            patterns["wolny"] = []
+
         return patterns
 
     def score(self, pattern: Pattern) -> PatternScore:


### PR DESCRIPTION
## Summary
- expose Wolny CP-SAT layout in `PatternSelector`
- include Wolny results in pallet tab and add buttons
- allow stepping through Wolny solutions with *Następny* and *Poprzedni*

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e39c12c6c8325b3d0dc500f75c16e