### PR TITLE
Ensure Wolny layout activates when cycling

### DIFF
--- a/packing_app/core/algorithms.py
+++ b/packing_app/core/algorithms.py
@@ -505,6 +505,8 @@ def pack_rectangles_dynamic(width, height, wprod, lprod, margin=0):
 def _build_cp_model(W_i, H_i, w_i, h_i, N):
     """Return (model, vars_) for the CP-SAT solver."""
     from ortools.sat.python import cp_model
+    import random
+    import random
 
     m = cp_model.CpModel()
     x = [m.NewIntVar(0, W_i, f"x{i}") for i in range(N)]
@@ -552,6 +554,7 @@ def enumerate_packings_wolny(
     want=15,
     time_first=20,
     time_each=20,
+    seed=None,
 ):
     """Enumerate rectangle packings using a CP-SAT search (WOLNY)."""
     from ortools.sat.python import cp_model
@@ -559,6 +562,8 @@ def enumerate_packings_wolny(
     scale = 1000
     W_i, H_i = round(width * scale), round(height * scale)
     w_i, h_i = round(wprod * scale), round(lprod * scale)
+    if seed is None:
+        seed = random.randint(0, 1_000_000)
     if min(W_i, H_i, w_i, h_i) <= 0:
         return []
 
@@ -573,6 +578,8 @@ def enumerate_packings_wolny(
 
         solver = cp_model.CpSolver()
         solver.parameters.max_time_in_seconds = time_first
+        if seed is not None:
+            solver.parameters.random_seed = seed
         status = solver.Solve(model)
         if status not in (cp_model.OPTIMAL, cp_model.FEASIBLE):
             continue
@@ -586,6 +593,8 @@ def enumerate_packings_wolny(
 
             solver2 = cp_model.CpSolver()
             solver2.parameters.max_time_in_seconds = time_each
+            if seed is not None:
+                solver2.parameters.random_seed = seed
             solver2.parameters.enumerate_all_solutions = True
             solver2.parameters.num_search_workers = 8
 
@@ -621,6 +630,7 @@ def pack_rectangles_wolny(width, height, wprod, lprod, *, time_limit=1.0):
         want=1,
         time_first=time_limit,
         time_each=time_limit,
+        seed=0,
     )
     if not result:
         return 0, []

--- a/packing_app/gui/tab_pallet.py
+++ b/packing_app/gui/tab_pallet.py
@@ -828,6 +828,7 @@ class TabPallet(ttk.Frame):
                 want=15,
                 time_first=5,
                 time_each=3,
+                seed=0,
             )
             if wolny_res:
                 self.wolny_solutions, self.wolny_get_next = (
@@ -1615,8 +1616,42 @@ class TabPallet(ttk.Frame):
         patt = apply_spacing(self.wolny_solutions[self.wolny_index], spacing)
         centered = self.center_layout(patt, pallet_w, pallet_l)
         self.layouts[idx] = (len(centered), centered, "Wolny")
+        # When cycling through "Wolny" layouts make sure it is the active
+        # pattern for both odd and even layers so the preview updates even if
+        # another layout was previously selected.
+        if hasattr(self, "odd_layout_var") and self.odd_layout_var.get() != "Wolny":
+            self.odd_layout_var.set("Wolny")
+        if hasattr(self, "even_layout_var") and self.even_layout_var.get() != "Wolny":
+            self.even_layout_var.set("Wolny")
         self.update_layers()
         self.draw_pallet()
+
+    def generate_wolny_solution(self) -> bool:
+        """Attempt to generate a new Wolny layout via CP-SAT search."""
+        pallet_w = parse_dim(self.pallet_w_var)
+        pallet_l = parse_dim(self.pallet_l_var)
+        thickness = parse_dim(self.cardboard_thickness_var)
+        spacing = parse_dim(self.spacing_var)
+        box_w = parse_dim(self.box_w_var) + 2 * thickness
+        box_l = parse_dim(self.box_l_var) + 2 * thickness
+        res = algorithms.enumerate_packings_wolny(
+            pallet_w,
+            pallet_l,
+            box_w + spacing,
+            box_l + spacing,
+            want=1,
+            time_first=3,
+            time_each=2,
+        )
+        if not res:
+            return False
+        sols, _ = res if isinstance(res, tuple) else (res, None)
+        layout = sols[0]
+        if layout in self.wolny_solutions:
+            return False
+        self.wolny_solutions.append(layout)
+        self.wolny_index = len(self.wolny_solutions) - 1
+        return True
 
     def next_wolny(self) -> None:
         if self.wolny_index + 1 < len(self.wolny_solutions):
@@ -1626,12 +1661,30 @@ class TabPallet(ttk.Frame):
             if nxt:
                 self.wolny_solutions.append(nxt)
                 self.wolny_index += 1
+        else:
+            self.generate_wolny_solution()
         self.update_wolny_layout()
+        if self.wolny_index + 1 >= len(self.wolny_solutions) and not self.wolny_get_next:
+            self.next_btn.state(["disabled"])
+        else:
+            self.next_btn.state(["!disabled"])
+        if self.wolny_index > 0:
+            self.prev_btn.state(["!disabled"])
+        else:
+            self.prev_btn.state(["disabled"])
 
     def prev_wolny(self) -> None:
         if self.wolny_index > 0:
             self.wolny_index -= 1
         self.update_wolny_layout()
+        if self.wolny_index == 0:
+            self.prev_btn.state(["disabled"])
+        else:
+            self.prev_btn.state(["!disabled"])
+        if self.wolny_index + 1 >= len(self.wolny_solutions) and not self.wolny_get_next:
+            self.next_btn.state(["disabled"])
+        else:
+            self.next_btn.state(["!disabled"])
 
     # ------------------------------------------------------------------
     # JSON pattern export / import helpers

--- a/palletizer_core/selector.py
+++ b/palletizer_core/selector.py
@@ -155,7 +155,14 @@ class PatternSelector:
 
         # wolny CP-SAT search
         res = algorithms.enumerate_packings_wolny(
-            pallet_w, pallet_l, box_w, box_l, want=1, time_first=2, time_each=2
+            pallet_w,
+            pallet_l,
+            box_w,
+            box_l,
+            want=1,
+            time_first=2,
+            time_each=2,
+            seed=0,
         )
         if res:
             sol, _ = res if isinstance(res, tuple) else (res, None)


### PR DESCRIPTION
## Summary
- update Wolny search to accept a random seed
- generate new Wolny layouts on demand when cycling
- keep deterministic behaviour for other code paths

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686e411429a083259013039d553a6ad4