### PR TITLE
Fix UR CAPS preview order handling

### DIFF
--- a/src/packing_app/gui/tab_ur_caps.py
+++ b/src/packing_app/gui/tab_ur_caps.py
@@ -1187,12 +1187,18 @@ class TabURCaps(ttk.Frame):
         signature = self._current_signature(layer_idx)
         if not signature:
             return
-        rect_count = len(snapshot.layer_rects_list[layer_idx - 1])
         target_sides = self._edit_target_sides()
         selection = self.order_tree.selection()
         if not selection:
             return
         selected_index = self.order_tree.index(selection[0])
+        base_side = self._display_side()
+        base_order = self._ensure_manual_order_for_signature(
+            signature,
+            len(snapshot.layer_rects_list[layer_idx - 1]),
+            base_side,
+        )
+        rect_count = len(base_order)
         target = selected_index + delta
         if target < 0 or target >= rect_count:
             return
@@ -1368,9 +1374,6 @@ class TabURCaps(ttk.Frame):
         ur_config = self._collect_config()
         config = self._make_pally_config(snapshot, ur_config, name_override="preview")
         self._update_signature_context(snapshot, config)
-        manual_orders = self._manual_orders_payload(snapshot)
-        orders_right, orders_left = manual_orders if manual_orders else (None, None)
-
         return build_pally_json(
             config=config,
             layer_rects_list=snapshot.layer_rects_list,
@@ -1378,8 +1381,8 @@ class TabURCaps(ttk.Frame):
             include_base_slip=(
                 bool(self.pally_slip_vars[0].get()) if self.pally_slip_vars else True
             ),
-            manual_orders_by_signature_right=orders_right,
-            manual_orders_by_signature_left=orders_left,
+            manual_orders_by_signature_right=None,
+            manual_orders_by_signature_left=None,
         )
 
     def _extract_layer_patterns(

--- a/tests/test_ur_caps_preview.py
+++ b/tests/test_ur_caps_preview.py
@@ -1,0 +1,43 @@
+import matplotlib.pyplot as plt
+
+from packing_app.gui.tab_ur_caps import TabURCaps
+
+
+def test_draw_layer_pattern_sequence_order(monkeypatch):
+    tab = TabURCaps.__new__(TabURCaps)
+    monkeypatch.setattr(tab, "_draw_approach_arrow", lambda *args, **kwargs: None)
+    monkeypatch.setattr(tab, "_draw_empty_preview", lambda *args, **kwargs: None)
+
+    payload = {
+        "dimensions": {"width": 100.0, "length": 100.0},
+        "productDimensions": {"width": 10.0, "length": 10.0},
+    }
+    pattern = [
+        {"x": 10.0, "y": 10.0, "r": [0]},
+        {"x": 20.0, "y": 10.0, "r": [0]},
+        {"x": 30.0, "y": 10.0, "r": [0]},
+    ]
+    order = [2, 0, 1]
+
+    fig, ax = plt.subplots()
+    annotations: list[tuple[tuple[float, float], tuple[float, float]]] = []
+
+    def capture_annotate(*args, **kwargs):
+        annotations.append((kwargs["xytext"], kwargs["xy"]))
+
+    monkeypatch.setattr(ax, "annotate", capture_annotate)
+
+    tab._draw_layer_pattern(
+        ax=ax,
+        payload=payload,
+        pattern=pattern,
+        layer_idx=1,
+        approach="normal",
+        side="right",
+        order=order,
+    )
+
+    assert annotations == [
+        ((30.0, 10.0), (10.0, 10.0)),
+        ((10.0, 10.0), (20.0, 10.0)),
+    ]


### PR DESCRIPTION
### Motivation
- Preview arrows in UR CAPS were rendered inconsistently because manual ordering was applied twice: once when building the preview payload and again when the preview drew arrows.
- Moving items Up/Down could allow moves outside the order actually displayed because `rect_count` was taken from the snapshot rather than from the active manual order.
- The preview should not mutate or re-order the payload; manual orders must only affect numbering and arrow drawing in the preview.
- Need a small unit test to assert arrow drawing order is correct and CI-safe (headless). 

### Description
- In `_build_preview_payload` stop passing `manual_orders_by_signature_*` to `build_pally_json` and always pass `None` for preview so the preview payload preserves the base `pattern` order.
- In `_move_selected` compute `rect_count` from the currently used manual order for the displayed side (via `_ensure_manual_order_for_signature`) to keep Up/Down bounds consistent with what is shown.
- Keep export behavior unchanged: `export_pally_json` still passes manual orders to `build_pally_json` so exported PALLY JSON reflects manual ordering.
- Add unit test `tests/test_ur_caps_preview.py::test_draw_layer_pattern_sequence_order` that monkeypatches an `ax.annotate` to capture arrows and asserts the annotated sequence matches the provided `order` permutation.

### Testing
- Ran `pytest` across the repository.
- All tests passed: `112 passed` (including the new `test_draw_layer_pattern_sequence_order`).
- The added test uses `matplotlib` with the `Agg` backend (configured in `tests/conftest.py`) so it is CI/headless safe.
- No changes to export behavior were introduced and existing export-related tests continued to pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696141d249988325bad5b3c4747fc02c)