### PR TITLE
Dodanie zakładki „Pusta przestrzeń POJEMNIKI” i modułu obliczeń

### DIFF
--- a/src/packing_app/__main__.py
+++ b/src/packing_app/__main__.py
@@ -26,6 +26,7 @@ def main() -> None:
     from packing_app.gui.tab_indirect_packaging import TabIndirectPackaging
     from packing_app.gui.tab_auxiliary import TabAuxiliaryMaterials
     from packing_app.gui.tab_ur_caps import TabURCaps
+    from packing_app.gui.tab_empty_space import TabEmptySpaceContainers
 
     app_version = _get_app_version()
 
@@ -56,6 +57,7 @@ def main() -> None:
     tab5 = TabIndirectPackaging(notebook)
     tab6 = TabAuxiliaryMaterials(notebook)
     tab7 = TabCartons(notebook)
+    tab8 = TabEmptySpaceContainers(notebook)
     tab1.set_pallet_tab(tab3)
     tab3.set_ur_caps_tab(tab_ur_caps)
 
@@ -67,6 +69,7 @@ def main() -> None:
     notebook.add(tab5, text="Opakowanie pośrednie")
     notebook.add(tab6, text="Materiały pomocnicze")
     notebook.add(tab7, text="Kartony")
+    notebook.add(tab8, text="Pusta przestrzeń POJEMNIKI")
 
     root.mainloop()
 

--- a/src/packing_app/core/empty_space.py
+++ b/src/packing_app/core/empty_space.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+
+MM3_IN_CC = 1000.0
+
+
+@dataclass(frozen=True)
+class EmptySpaceResult:
+    """Wyniki obliczeń dla zakładki pustej przestrzeni pojemnika."""
+
+    volume_unit_mm3: float
+    volume_unit_cc: float
+    total_volume_cc: float
+    fill_percent: float
+    empty_percent: float
+    free_volume_cc: float
+
+
+
+def volume_round_mm3(diameter_mm: float) -> float:
+    """Objętość kuli na podstawie średnicy (mm^3)."""
+    radius = diameter_mm / 2.0
+    return (4.0 / 3.0) * math.pi * radius**3
+
+
+
+def volume_oval_mm3(length_mm: float, width_mm: float, height_mm: float) -> float:
+    """Objętość elipsoidy 3D na podstawie długości, szerokości i wysokości (mm^3)."""
+    return math.pi * length_mm * width_mm * height_mm / 6.0
+
+
+
+def volume_oblong_mm3(total_length_mm: float, diameter_mm: float) -> float:
+    """Objętość kapsułki (walec + dwie półkule) w mm^3."""
+    radius = diameter_mm / 2.0
+    cylinder_length = max(total_length_mm - diameter_mm, 0.0)
+    cylinder_volume = math.pi * radius**2 * cylinder_length
+    sphere_volume = (4.0 / 3.0) * math.pi * radius**3
+    return cylinder_volume + sphere_volume
+
+
+
+def calculate_empty_space(
+    *,
+    unit_volume_mm3: float,
+    quantity: int,
+    container_volume_cc: float,
+) -> EmptySpaceResult:
+    """Oblicza zajętość i pustą przestrzeń pojemnika dla zadanej liczby sztuk."""
+    volume_unit_cc = unit_volume_mm3 / MM3_IN_CC
+    total_volume_cc = volume_unit_cc * quantity
+    fill_percent = (total_volume_cc / container_volume_cc) * 100.0
+    empty_percent = 100.0 - fill_percent
+    free_volume_cc = container_volume_cc - total_volume_cc
+    return EmptySpaceResult(
+        volume_unit_mm3=unit_volume_mm3,
+        volume_unit_cc=volume_unit_cc,
+        total_volume_cc=total_volume_cc,
+        fill_percent=fill_percent,
+        empty_percent=empty_percent,
+        free_volume_cc=free_volume_cc,
+    )

--- a/src/packing_app/gui/tab_empty_space.py
+++ b/src/packing_app/gui/tab_empty_space.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import ttk
+
+from packing_app.core.empty_space import (
+    EmptySpaceResult,
+    calculate_empty_space,
+    volume_oblong_mm3,
+    volume_oval_mm3,
+    volume_round_mm3,
+)
+
+
+class TabEmptySpaceContainers(ttk.Frame):
+    """Zakładka do obliczania pustej przestrzeni w pojemniku typu pilljar."""
+
+    SHAPE_ROUND = "okrągły"
+    SHAPE_OVAL = "owalny"
+    SHAPE_OBLONG = "podłużny"
+
+    def __init__(self, parent):
+        super().__init__(parent)
+        self.shape_var = tk.StringVar(value=self.SHAPE_ROUND)
+        self.quantity_var = tk.StringVar(value="1")
+        self.container_volume_var = tk.StringVar(value="50")
+
+        self.diameter_var = tk.StringVar(value="")
+        self.length_var = tk.StringVar(value="")
+        self.width_var = tk.StringVar(value="")
+        self.height_var = tk.StringVar(value="")
+        self.total_length_var = tk.StringVar(value="")
+
+        self.warning_var = tk.StringVar(value="")
+        self.result_unit_mm3_var = tk.StringVar(value="-")
+        self.result_unit_cc_var = tk.StringVar(value="-")
+        self.result_total_cc_var = tk.StringVar(value="-")
+        self.result_fill_percent_var = tk.StringVar(value="-")
+        self.result_empty_percent_var = tk.StringVar(value="-")
+        self.result_free_cc_var = tk.StringVar(value="-")
+
+        self._numeric_vcmd = (self.register(self._validate_decimal_input), "%P")
+        self._integer_vcmd = (self.register(self._validate_integer_input), "%P")
+
+        self._dimensions_frame: ttk.Frame | None = None
+        self.build_ui()
+
+    def build_ui(self) -> None:
+        self.columnconfigure(0, weight=1)
+
+        form = ttk.LabelFrame(self, text="Parametry")
+        form.grid(row=0, column=0, sticky="ew", padx=8, pady=(8, 4))
+        form.columnconfigure(1, weight=1)
+
+        ttk.Label(form, text="Kształt:").grid(row=0, column=0, sticky="e", padx=4, pady=4)
+        shape_combo = ttk.Combobox(
+            form,
+            textvariable=self.shape_var,
+            values=[self.SHAPE_ROUND, self.SHAPE_OVAL, self.SHAPE_OBLONG],
+            state="readonly",
+            width=20,
+        )
+        shape_combo.grid(row=0, column=1, sticky="w", padx=4, pady=4)
+        shape_combo.bind("<<ComboboxSelected>>", self._on_shape_changed)
+
+        ttk.Label(form, text="Liczba sztuk:").grid(row=1, column=0, sticky="e", padx=4, pady=4)
+        ttk.Entry(
+            form,
+            textvariable=self.quantity_var,
+            width=20,
+            validate="key",
+            validatecommand=self._integer_vcmd,
+        ).grid(row=1, column=1, sticky="w", padx=4, pady=4)
+
+        ttk.Label(form, text="Objętość pojemnika [cc]:").grid(
+            row=2, column=0, sticky="e", padx=4, pady=4
+        )
+        ttk.Entry(
+            form,
+            textvariable=self.container_volume_var,
+            width=20,
+            validate="key",
+            validatecommand=self._numeric_vcmd,
+        ).grid(row=2, column=1, sticky="w", padx=4, pady=4)
+
+        self._dimensions_frame = ttk.LabelFrame(self, text="Wymiary jednostki")
+        self._dimensions_frame.grid(row=1, column=0, sticky="ew", padx=8, pady=4)
+        self._dimensions_frame.columnconfigure(1, weight=1)
+
+        button_frame = ttk.Frame(self)
+        button_frame.grid(row=2, column=0, sticky="w", padx=8, pady=(4, 8))
+        ttk.Button(button_frame, text="Oblicz", command=self.calculate).pack(side=tk.LEFT)
+
+        results = ttk.LabelFrame(self, text="Wyniki")
+        results.grid(row=3, column=0, sticky="ew", padx=8, pady=(0, 8))
+
+        self._result_row(results, 0, "Objętość 1 sztuki [mm³]:", self.result_unit_mm3_var)
+        self._result_row(results, 1, "Objętość 1 sztuki [cc]:", self.result_unit_cc_var)
+        self._result_row(results, 2, "Objętość całkowita [cc]:", self.result_total_cc_var)
+        self._result_row(results, 3, "Zajętość pojemnika [%]:", self.result_fill_percent_var)
+        self._result_row(results, 4, "Pusta przestrzeń [%]:", self.result_empty_percent_var)
+        self._result_row(results, 5, "Wolna objętość [cc]:", self.result_free_cc_var)
+
+        ttk.Label(self, textvariable=self.warning_var, foreground="#b44d00").grid(
+            row=4, column=0, sticky="w", padx=10, pady=(0, 8)
+        )
+
+        self._render_dimension_fields()
+
+    def _result_row(self, parent: ttk.Frame, row: int, label: str, variable: tk.StringVar) -> None:
+        ttk.Label(parent, text=label).grid(row=row, column=0, sticky="w", padx=6, pady=2)
+        ttk.Label(parent, textvariable=variable).grid(row=row, column=1, sticky="e", padx=6, pady=2)
+
+    def _render_dimension_fields(self) -> None:
+        if self._dimensions_frame is None:
+            return
+        for widget in self._dimensions_frame.winfo_children():
+            widget.destroy()
+
+        shape = self.shape_var.get()
+        if shape == self.SHAPE_ROUND:
+            self._add_dimension_entry(0, "Średnica [mm]:", self.diameter_var)
+        elif shape == self.SHAPE_OVAL:
+            self._add_dimension_entry(0, "Długość [mm]:", self.length_var)
+            self._add_dimension_entry(1, "Szerokość [mm]:", self.width_var)
+            self._add_dimension_entry(2, "Wysokość / grubość [mm]:", self.height_var)
+        elif shape == self.SHAPE_OBLONG:
+            self._add_dimension_entry(0, "Długość [mm]:", self.total_length_var)
+            self._add_dimension_entry(1, "Średnica [mm]:", self.diameter_var)
+
+    def _add_dimension_entry(self, row: int, label: str, variable: tk.StringVar) -> None:
+        assert self._dimensions_frame is not None
+        ttk.Label(self._dimensions_frame, text=label).grid(row=row, column=0, sticky="e", padx=4, pady=4)
+        ttk.Entry(
+            self._dimensions_frame,
+            textvariable=variable,
+            width=20,
+            validate="key",
+            validatecommand=self._numeric_vcmd,
+        ).grid(row=row, column=1, sticky="w", padx=4, pady=4)
+
+    def _on_shape_changed(self, _: tk.Event) -> None:
+        self.warning_var.set("")
+        self._clear_results()
+        self._render_dimension_fields()
+
+    def calculate(self) -> None:
+        try:
+            quantity = self._parse_positive_integer(self.quantity_var.get(), "Liczba sztuk")
+            container_cc = self._parse_positive_float(
+                self.container_volume_var.get(), "Objętość pojemnika [cc]"
+            )
+            unit_volume_mm3 = self._calculate_unit_volume_mm3()
+            result = calculate_empty_space(
+                unit_volume_mm3=unit_volume_mm3,
+                quantity=quantity,
+                container_volume_cc=container_cc,
+            )
+        except ValueError as error:
+            self.warning_var.set(str(error))
+            self._clear_results()
+            return
+
+        self._show_results(result)
+
+    def _calculate_unit_volume_mm3(self) -> float:
+        shape = self.shape_var.get()
+        if shape == self.SHAPE_ROUND:
+            diameter_mm = self._parse_positive_float(self.diameter_var.get(), "Średnica [mm]")
+            return volume_round_mm3(diameter_mm)
+        if shape == self.SHAPE_OVAL:
+            length_mm = self._parse_positive_float(self.length_var.get(), "Długość [mm]")
+            width_mm = self._parse_positive_float(self.width_var.get(), "Szerokość [mm]")
+            height_mm = self._parse_positive_float(self.height_var.get(), "Wysokość / grubość [mm]")
+            return volume_oval_mm3(length_mm, width_mm, height_mm)
+
+        total_length_mm = self._parse_positive_float(self.total_length_var.get(), "Długość [mm]")
+        diameter_mm = self._parse_positive_float(self.diameter_var.get(), "Średnica [mm]")
+        return volume_oblong_mm3(total_length_mm, diameter_mm)
+
+    def _show_results(self, result: EmptySpaceResult) -> None:
+        self.result_unit_mm3_var.set(self._format_number(result.volume_unit_mm3, 3))
+        self.result_unit_cc_var.set(self._format_number(result.volume_unit_cc, 6))
+        self.result_total_cc_var.set(self._format_number(result.total_volume_cc, 6))
+        self.result_fill_percent_var.set(self._format_number(result.fill_percent, 2))
+        self.result_empty_percent_var.set(self._format_number(result.empty_percent, 2))
+        self.result_free_cc_var.set(self._format_number(result.free_volume_cc, 6))
+
+        if result.total_volume_cc > self._parse_decimal_or_zero(self.container_volume_var.get()):
+            self.warning_var.set(
+                "Ostrzeżenie: objętość produktu przekracza objętość pojemnika."
+            )
+        else:
+            self.warning_var.set("")
+
+    def _clear_results(self) -> None:
+        for variable in (
+            self.result_unit_mm3_var,
+            self.result_unit_cc_var,
+            self.result_total_cc_var,
+            self.result_fill_percent_var,
+            self.result_empty_percent_var,
+            self.result_free_cc_var,
+        ):
+            variable.set("-")
+
+    def _parse_positive_float(self, value: str, field_name: str) -> float:
+        normalized = value.replace(",", ".").strip()
+        if not normalized:
+            raise ValueError(f"Pole „{field_name}” jest wymagane.")
+        try:
+            parsed = float(normalized)
+        except ValueError as error:
+            raise ValueError(f"Pole „{field_name}” musi być liczbą dodatnią.") from error
+
+        if parsed <= 0:
+            raise ValueError(f"Pole „{field_name}” musi być większe od zera.")
+        return parsed
+
+    def _parse_positive_integer(self, value: str, field_name: str) -> int:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError(f"Pole „{field_name}” jest wymagane.")
+        try:
+            parsed = int(normalized)
+        except ValueError as error:
+            raise ValueError(f"Pole „{field_name}” musi być liczbą całkowitą dodatnią.") from error
+
+        if parsed <= 0:
+            raise ValueError(f"Pole „{field_name}” musi być większe od zera.")
+        return parsed
+
+    def _parse_decimal_or_zero(self, value: str) -> float:
+        try:
+            return float(value.replace(",", ".").strip())
+        except ValueError:
+            return 0.0
+
+    def _format_number(self, value: float, precision: int) -> str:
+        return f"{value:.{precision}f}".replace(".", ",")
+
+    def _validate_decimal_input(self, value: str) -> bool:
+        if value == "":
+            return True
+        normalized = value.replace(",", ".")
+        if normalized.count(".") > 1:
+            return False
+        if normalized in {".", ","}:
+            return True
+        try:
+            return float(normalized) >= 0
+        except ValueError:
+            return False
+
+    def _validate_integer_input(self, value: str) -> bool:
+        if value == "":
+            return True
+        return value.isdigit()

--- a/tests/test_empty_space.py
+++ b/tests/test_empty_space.py
@@ -1,0 +1,46 @@
+import math
+
+from packing_app.core.empty_space import (
+    calculate_empty_space,
+    volume_oblong_mm3,
+    volume_oval_mm3,
+    volume_round_mm3,
+)
+
+
+def test_round_volume_matches_sphere_formula():
+    diameter = 10.0
+    expected = (4.0 / 3.0) * math.pi * 5.0**3
+    assert volume_round_mm3(diameter) == expected
+
+
+def test_oval_volume_matches_ellipsoid_formula():
+    length, width, height = 12.0, 8.0, 6.0
+    expected = math.pi * length * width * height / 6.0
+    assert volume_oval_mm3(length, width, height) == expected
+
+
+def test_oblong_volume_uses_non_negative_cylinder_part_when_length_is_shorter_than_diameter():
+    total_length = 8.0
+    diameter = 10.0
+    expected = (4.0 / 3.0) * math.pi * 5.0**3
+    assert volume_oblong_mm3(total_length, diameter) == expected
+
+
+def test_calculate_empty_space_returns_expected_percentages_and_free_volume():
+    result = calculate_empty_space(unit_volume_mm3=1000.0, quantity=20, container_volume_cc=50.0)
+
+    assert result.volume_unit_cc == 1.0
+    assert result.total_volume_cc == 20.0
+    assert result.fill_percent == 40.0
+    assert result.empty_percent == 60.0
+    assert result.free_volume_cc == 30.0
+
+
+def test_calculate_empty_space_allows_overfill_values():
+    result = calculate_empty_space(unit_volume_mm3=2000.0, quantity=40, container_volume_cc=50.0)
+
+    assert result.total_volume_cc == 80.0
+    assert result.fill_percent == 160.0
+    assert result.empty_percent == -60.0
+    assert result.free_volume_cc == -30.0


### PR DESCRIPTION
### Motivation
- Dostarczyć w istniejącej aplikacji zakładkę pozwalającą policzyć, ile procent objętości pojemnika zajmuje zadana liczba kapsułek/tabletek oraz ile pozostaje pustej przestrzeni, zgodnie z ustalonymi wzorami i wymaganiami UI po polsku.

### Description
- Dodano moduł obliczeń `src/packing_app/core/empty_space.py` zawierający funkcje `volume_round_mm3`, `volume_oval_mm3`, `volume_oblong_mm3` oraz `calculate_empty_space` i strukturę wyników `EmptySpaceResult` (przeliczenia mm³ <-> cc i logika procentów).
- Dodano zakładkę GUI `src/packing_app/gui/tab_empty_space.py` implementującą `TabEmptySpaceContainers` z polskim UI, wyborem kształtu (`okrągły`, `owalny`, `podłużny`), walidacją pól, domyślną objętością pojemnika `50 cc` oraz przyciskiem `Oblicz` i czytelną sekcją wyników i ostrzeżeń.
- Zaktualizowano `src/packing_app/__main__.py`, aby zarejestrować nową zakładkę w istniejącym `ttk.Notebook` pod etykietą `Pusta przestrzeń POJEMNIKI`.
- Dodano testy jednostkowe `tests/test_empty_space.py` pokrywające wzory objętości dla wszystkich kształtów, przypadek `L < d` (użycie `max(L - d, 0)`) oraz prawidłowe obliczenia procentów i wolnej objętości (w tym przypadek przepełnienia).

### Testing
- Uruchomiono jednostkowe testy tylko dla nowego modułu: `pytest tests/test_empty_space.py`.
- Wynik: wszystkie testy przeszły sukcesem (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5fb8e55c08325b1843ed4ae58264a)