### PR TITLE
Improve drag detection, rounding behavior, and 2D/pallet GUI features

### DIFF
--- a/src/packing_app/gui/editor_controller.py
+++ b/src/packing_app/gui/editor_controller.py
@@ -98,13 +98,25 @@ class EditorController:
             "clear_layer": clear_layer,
         }
 
-    def on_motion(self, x: float, y: float) -> Dict[str, object]:
+    def on_motion(
+        self,
+        x: float,
+        y: float,
+        screen_x: float | None = None,
+        screen_y: float | None = None,
+    ) -> Dict[str, object]:
         if self.pressed_button != 1:
             return {}
         if self.drag_start is None:
             return {}
 
-        distance = hypot(x - self.drag_start[0], y - self.drag_start[1])
+        if screen_x is not None and screen_y is not None:
+            if not hasattr(self, "_screen_drag_start"):
+                self._screen_drag_start = (screen_x, screen_y)
+            sx, sy = self._screen_drag_start
+            distance = hypot(screen_x - sx, screen_y - sy)
+        else:
+            distance = hypot(x - self.drag_start[0], y - self.drag_start[1])
         if distance > self.drag_threshold_px:
             self.is_dragging = True
 
@@ -124,6 +136,8 @@ class EditorController:
         self.last_pos = None
         self.is_dragging = False
         self.pressed_button = None
+        if hasattr(self, "_screen_drag_start"):
+            delattr(self, "_screen_drag_start")
         return {"was_dragging": was_dragging}
 
     def reset_drag_state(self) -> None:
@@ -131,3 +145,5 @@ class EditorController:
         self.last_pos = None
         self.is_dragging = False
         self.pressed_button = None
+        if hasattr(self, "_screen_drag_start"):
+            delattr(self, "_screen_drag_start")

--- a/src/packing_app/gui/tab_2d.py
+++ b/src/packing_app/gui/tab_2d.py
@@ -51,7 +51,8 @@ class TabPacking2D(ttk.Frame):
         ttk.Label(f_carton, text="Wybierz karton:").grid(
             row=0, column=0, sticky="w", padx=4, pady=(2, 1)
         )
-        self.carton_choice = tk.StringVar(value="Manual")
+        self.manual_carton_label = "Ręcznie"
+        self.carton_choice = tk.StringVar(value=self.manual_carton_label)
         self.cb_carton = ttk.Combobox(
             f_carton,
             textvariable=self.carton_choice,
@@ -248,11 +249,28 @@ class TabPacking2D(ttk.Frame):
         self.use_cushions = tk.BooleanVar(value=False)
         ttk.Checkbutton(
             f_settings,
-            text="Poduszki z powietrzem (37×175×110 mm)",
+            text="Poduszki z powietrzem",
             variable=self.use_cushions,
             command=self.show_packing,
         ).grid(row=0, column=2, columnspan=4, sticky="w", padx=4, pady=(2, 1))
         self.use_cushions.trace_add("write", lambda *args: self.show_packing())
+
+        ttk.Label(f_settings, text="Poduszka W/L/H [mm]:").grid(
+            row=6, column=0, sticky="w", padx=4, pady=(0, 2)
+        )
+        self.cushion_w = tk.StringVar(value="37")
+        self.cushion_l = tk.StringVar(value="175")
+        self.cushion_h = tk.StringVar(value="110")
+        for col, var in enumerate((self.cushion_w, self.cushion_l, self.cushion_h), start=1):
+            entry = ttk.Entry(
+                f_settings,
+                textvariable=var,
+                width=8,
+                validate="key",
+                validatecommand=(self.register(self.validate_number), "%P"),
+            )
+            entry.grid(row=6, column=col, sticky="w", padx=(2, 4), pady=(0, 2))
+            entry.bind("<Return>", self.on_enter_pressed)
 
         ttk.Label(f_settings, text="Odstęp poduszek [mm]:").grid(
             row=1, column=0, sticky="w", padx=4, pady=(0, 1)
@@ -392,6 +410,9 @@ class TabPacking2D(ttk.Frame):
         self.prod_diam.trace_add("write", self.on_prod_diam_changed)
         self.display_mode.trace_add("write", lambda *args: self.show_packing())
         self.display_manual_spacing.trace_add("write", lambda *args: self.show_packing())
+        self.cushion_w.trace_add("write", lambda *args: self.show_packing())
+        self.cushion_l.trace_add("write", lambda *args: self.show_packing())
+        self.cushion_h.trace_add("write", lambda *args: self.show_packing())
         self.on_prod_diam_changed()
         self.update_carton_list()
         self.update_product_fields()
@@ -450,12 +471,12 @@ class TabPacking2D(ttk.Frame):
         current_l = self.parse_dim_safe(self.carton_l)
         current_h = self.parse_dim_safe(self.carton_h)
         selected_carton = self.carton_choice.get()
-        if selected_carton != "Manual":
-            key = selected_carton.split()[0]
+        if selected_carton != self.manual_carton_label:
+            key = selected_carton.split(":")[0]
             if key in self.predefined_cartons:
                 w, length, h = self.predefined_cartons[key]
                 if current_w != w or current_l != length or current_h != h:
-                    self.carton_choice.set("Manual")
+                    self.carton_choice.set(self.manual_carton_label)
 
     def draw_carton_and_margin(self, ax, width, height, margin):
         ax.add_patch(plt.Rectangle((0, 0), width, height, fill=False, edgecolor='black'))
@@ -465,11 +486,24 @@ class TabPacking2D(ttk.Frame):
 
     def add_air_cushions(self, ax, width, height, positions, h_c):
         if self.use_cushions.get():
-            cushion_positions = place_air_cushions(width, height, positions, min_gap=self.parse_dim_safe(self.cushion_gap), offset_x=self.parse_dim_safe(self.offset_x), offset_y=self.parse_dim_safe(self.offset_y))
+            cushion_w = max(self.parse_dim_safe(self.cushion_w), 1)
+            cushion_l = max(self.parse_dim_safe(self.cushion_l), 1)
+            cushion_h = max(self.parse_dim_safe(self.cushion_h), 1)
+            cushion_positions = place_air_cushions(
+                width,
+                height,
+                positions,
+                cushion_w=cushion_w,
+                cushion_l=cushion_l,
+                cushion_h=cushion_h,
+                min_gap=self.parse_dim_safe(self.cushion_gap),
+                offset_x=self.parse_dim_safe(self.offset_x),
+                offset_y=self.parse_dim_safe(self.offset_y),
+            )
             for (x0, y0, ww, hh) in cushion_positions:
                 ax.add_patch(plt.Rectangle((x0, y0), ww, hh, fill=True, facecolor='yellow', edgecolor='black', alpha=0.5))
-            if h_c > 0 and h_c < 110:
-                messagebox.showinfo("Informacja", "Sprawdź fizycznie, czy poduszka się zmieści (wysokość poduszki: 110 mm).")
+            if h_c > 0 and h_c < cushion_h:
+                messagebox.showinfo("Informacja", f"Sprawdź fizycznie, czy poduszka się zmieści (wysokość poduszki: {cushion_h:.0f} mm).")
 
     def draw_vertical(self, ax, w_c, l_c, w_p, l_p, margin, h_c):
         c_vert, pos_vert = pack_rectangles_2d(w_c, l_c, w_p, l_p, margin)
@@ -584,7 +618,8 @@ class TabPacking2D(ttk.Frame):
     def _apply_display_grid(self, width, height, diam, centers, gap_x=None, gap_y=None):
         rows = self._group_rows(centers)
         row_count = len(rows)
-        col_count = max((len(row) for row in rows), default=0)
+        row_counts = [len(row) for row in rows]
+        col_count = max(row_counts, default=0)
         if row_count == 0 or col_count == 0:
             return centers, 0, 0, 0, 0
         if gap_x is None:
@@ -594,12 +629,22 @@ class TabPacking2D(ttk.Frame):
         step_x = diam + gap_x
         step_y = diam + gap_y
         new_centers = []
-        for row_idx in range(row_count):
+        for row_idx, cols in enumerate(row_counts):
             cy = gap_y + diam / 2 + row_idx * step_y
-            for col_idx in range(col_count):
+            for col_idx in range(cols):
                 cx = gap_x + diam / 2 + col_idx * step_x
                 new_centers.append((cx, cy))
         return new_centers, gap_x, gap_y, row_count, col_count
+
+    def _centers_within_bounds(self, width, height, diam, centers):
+        r = diam / 2
+        return all(
+            cx - r >= -1e-6
+            and cy - r >= -1e-6
+            and cx + r <= width + 1e-6
+            and cy + r <= height + 1e-6
+            for cx, cy in centers
+        )
 
     def _apply_display_hex(self, width, height, diam, centers, gap_x=None, gap_y=None):
         rows = self._group_rows(centers)
@@ -663,8 +708,8 @@ class TabPacking2D(ttk.Frame):
             return
         self.syncing_display_carton = True
         try:
-            self.carton_w.set(f"{req_w:.2f}")
-            self.carton_l.set(f"{req_l:.2f}")
+            self.carton_w.set(f"{round(req_w):.0f}")
+            self.carton_l.set(f"{round(req_l):.0f}")
         finally:
             self.syncing_display_carton = False
 
@@ -702,10 +747,10 @@ class TabPacking2D(ttk.Frame):
                 label = f"{k}: {w}x{length}x{h} (luz: {free_space:.1f} mm)"
                 cvals.append((label, free_space))
         cvals.sort(key=lambda x: x[1])
-        cvals = ["Manual"] + [item[0] for item in cvals]
+        cvals = [self.manual_carton_label] + [item[0] for item in cvals]
         self.cb_carton["values"] = cvals
         current = self.carton_choice.get()
-        if current == "Manual":
+        if current == self.manual_carton_label:
             return
         if current in cvals:
             return
@@ -714,7 +759,7 @@ class TabPacking2D(ttk.Frame):
         if match:
             self.carton_choice.set(match)
         else:
-            self.carton_choice.set("Manual")
+            self.carton_choice.set(self.manual_carton_label)
 
     def update_layout_options(self):
         if self.prod_type.get() == "rectangle":
@@ -743,7 +788,7 @@ class TabPacking2D(ttk.Frame):
         try:
             self.updating_carton = True
             val = self.carton_choice.get()
-            if val != "Manual":
+            if val != self.manual_carton_label:
                 key = val.split(":")[0]
                 if key in self.predefined_cartons:
                     w, length, h = self.predefined_cartons[key]
@@ -837,10 +882,12 @@ class TabPacking2D(ttk.Frame):
             carton_area = w_c * l_c / 1_000_000
             prod_area = w_p * l_p / 1_000_000 if w_p > 0 and l_p > 0 else 0
             area_ratio = carton_area / prod_area if prod_area > 0 else 0
+            prod_area_cm2 = w_p * l_p / 100 if w_p > 0 and l_p > 0 else 0
             self.area_label.config(
                 text=(
                     f"Pow. kartonu: {carton_area:.3f} m² | "
-                    f"Pow. kartonika: {prod_area:.2f} m² | Miejsca: {area_ratio:.2f}"
+                    f"Pow. kartonika: {prod_area:.4f} m² ({prod_area_cm2:.1f} cm²) | "
+                    f"Miejsca: {area_ratio:.2f}"
                 )
             )
         else:
@@ -886,8 +933,22 @@ class TabPacking2D(ttk.Frame):
                     gap_y=display_gap_y if manual else None,
                 )
                 if not manual:
-                    self.display_gap_x.set(f"{gx:.2f}")
-                    self.display_gap_y.set(f"{gy:.2f}")
+                    self.display_gap_x.set(f"{round(gx):.0f}")
+                    self.display_gap_y.set(f"{round(gy):.0f}")
+                if manual:
+                    checks = (
+                        (w_c, l_c, grid_centers),
+                        (w_c, l_c, hex_centers),
+                        (l_c, w_c, rev_centers),
+                    )
+                    if not all(
+                        self._centers_within_bounds(width, height, diam, centers)
+                        for width, height, centers in checks
+                    ):
+                        messagebox.showwarning(
+                            "Ostrzeżenie",
+                            "Ręczne odstępy display wypychają część pojemników poza karton.",
+                        )
                 grid_shape = (grid_rows, grid_cols)
                 active_gap_x = display_gap_x if manual else gx
                 active_gap_y = display_gap_y if manual else gy
@@ -932,8 +993,8 @@ class TabPacking2D(ttk.Frame):
                     f"Siatka: {c_grid}\n"
                     f"Wolne miejsce na prawo={w_c - (mgx + r):.1f}\n"
                     f"Wolne miejsce do góry={l_c - (mgy + r):.1f}\n"
-                    f"Odstęp X/Y={self.parse_dim_safe(self.display_gap_x):.1f}/{self.parse_dim_safe(self.display_gap_y):.1f} mm\n"
-                    f"Odstęp po skosie={max(math.sqrt((diam + self.parse_dim_safe(self.display_gap_x))**2 + (diam + self.parse_dim_safe(self.display_gap_y))**2) - diam, 0):.1f} mm\n"
+                    f"Odstęp X/Y={self.parse_dim_safe(self.display_gap_x):.0f}/{self.parse_dim_safe(self.display_gap_y):.0f} mm\n"
+                    f"Odstęp po skosie={max(math.sqrt((diam + self.parse_dim_safe(self.display_gap_x))**2 + (diam + self.parse_dim_safe(self.display_gap_y))**2) - diam, 0):.0f} mm\n"
                     f"Zajętość pow.: {area_util:.1f}%\n"
                     f"Zajętość obj.: {vol_util:.1f}%",
                     fontsize=10
@@ -951,7 +1012,7 @@ class TabPacking2D(ttk.Frame):
                     f"Hex: {c_hex}\n"
                     f"Wolne miejsce na prawo={w_c - (mhx + r):.1f}\n"
                     f"Wolne miejsce do góry={l_c - (mhy + r):.1f}\n"
-                    f"Odstęp X/Y={self.parse_dim_safe(self.display_gap_x):.1f}/{self.parse_dim_safe(self.display_gap_y):.1f} mm\n"
+                    f"Odstęp X/Y={self.parse_dim_safe(self.display_gap_x):.0f}/{self.parse_dim_safe(self.display_gap_y):.0f} mm\n"
                     f"Zajętość pow.: {area_util:.1f}%\n"
                     f"Zajętość obj.: {vol_util:.1f}%",
                     fontsize=10
@@ -969,7 +1030,7 @@ class TabPacking2D(ttk.Frame):
                     f"Hex(rev): {c_rev}\n"
                     f"Wolne miejsce na prawo={l_c - (mrx + r):.1f}\n"
                     f"Wolne miejsce do góry={w_c - (mry + r):.1f}\n"
-                    f"Odstęp X/Y={self.parse_dim_safe(self.display_gap_x):.1f}/{self.parse_dim_safe(self.display_gap_y):.1f} mm\n"
+                    f"Odstęp X/Y={self.parse_dim_safe(self.display_gap_x):.0f}/{self.parse_dim_safe(self.display_gap_y):.0f} mm\n"
                     f"Zajętość pow.: {area_util:.1f}%\n"
                     f"Zajętość obj.: {vol_util:.1f}%",
                     fontsize=10
@@ -980,10 +1041,12 @@ class TabPacking2D(ttk.Frame):
             carton_area = w_c * l_c / 1_000_000
             prod_area = math.pi * (diam / 2) ** 2 / 1_000_000 if diam > 0 else 0
             area_ratio = carton_area / prod_area if prod_area > 0 else 0
+            prod_area_cm2 = math.pi * (diam / 2) ** 2 / 100 if diam > 0 else 0
             self.area_label.config(
                 text=(
                     f"Pow. kartonu: {carton_area:.3f} m² | "
-                    f"Pow. kartonika: {prod_area:.2f} m² | Miejsca: {area_ratio:.2f}"
+                    f"Pow. pojemnika: {prod_area:.4f} m² ({prod_area_cm2:.1f} cm²) | "
+                    f"Miejsca: {area_ratio:.2f}"
                 )
             )
 
@@ -1088,7 +1151,7 @@ class TabPacking2D(ttk.Frame):
         margin = self.parse_dim_safe(self.margin)
         carton_code = None
         val = self.carton_choice.get()
-        if val != "Manual":
+        if val != self.manual_carton_label:
             carton_code = val.split(":")[0]
         if carton_code:
             self.pallet_tab.carton_var.set(carton_code)

--- a/src/packing_app/gui/tab_pallet.py
+++ b/src/packing_app/gui/tab_pallet.py
@@ -183,11 +183,38 @@ class TabPallet(ttk.Frame):
 
     def _edit_target_layers(self, layer_idx: int, *, include_source: bool = True) -> list[int]:
         layers = _matching_layers_for_pattern(self, layer_idx)
-        if not self.edit_layers_linked():
+        if not TabPallet._safe_edit_layers_linked(self):
             layers = [idx for idx in layers if idx % 2 == layer_idx % 2]
         if include_source:
             return layers
         return [idx for idx in layers if idx != layer_idx]
+
+    def _safe_edit_layers_linked(self) -> bool:
+        checker = getattr(self, "edit_layers_linked", None)
+        if callable(checker):
+            return bool(checker())
+        checker = getattr(self, "layers_linked", None)
+        return bool(checker()) if callable(checker) else False
+
+    def _safe_edit_target_layers(
+        self, layer_idx: int, *, include_source: bool = True
+    ) -> list[int]:
+        getter = getattr(self, "_edit_target_layers", None)
+        if callable(getter) and getter is not TabPallet._safe_edit_target_layers:
+            try:
+                return list(getter(layer_idx, include_source=include_source))
+            except TypeError:
+                pass
+        layers = _matching_layers_for_pattern(self, layer_idx)
+        if not TabPallet._safe_edit_layers_linked(self):
+            layers = [idx for idx in layers if idx % 2 == layer_idx % 2]
+        if include_source:
+            return layers
+        return [idx for idx in layers if idx != layer_idx]
+
+    @staticmethod
+    def _round_mm(value: float) -> int:
+        return int(math.floor(value + 0.5))
 
     def _create_unique_pattern_id(self, base: str) -> str:
         normalized = base or "manual"
@@ -1514,7 +1541,7 @@ class TabPallet(ttk.Frame):
         self._clear_selection()
         self.editor_controller.active_layer = 0
         self.drag_info = None
-        if hasattr(self, "undo_stack"):
+        if hasattr(self, "undo_stack") and (force or not has_existing_layers):
             self.undo_stack.clear()
         odd_display = self.odd_layout_var.get()
         even_display = self.even_layout_var.get()
@@ -1925,6 +1952,10 @@ class TabPallet(ttk.Frame):
             return None
         pallet_w = parse_dim(self.pallet_w_var, on_error=silent_error)
         pallet_l = parse_dim(self.pallet_l_var, on_error=silent_error)
+        if not pallet_w or not pallet_l or pallet_w <= 0 or pallet_l <= 0:
+            if hasattr(self, "status_var"):
+                self.status_var.set("Niepoprawne wymiary palety – popraw W/L przed rysowaniem.")
+            return
         axes = [self.ax_odd, self.ax_even, self.ax_overlay]
         labels = ["Warstwa nieparzysta", "Warstwa parzysta", "Nakładanie"]
         self.patches = [[] for _ in axes[:2]]
@@ -2040,10 +2071,12 @@ class TabPallet(ttk.Frame):
             for patch, idx in patch_list:
                 if (layer_idx, idx) in self.selected_indices:
                     patch.set_edgecolor("orange")
-                    patch.set_linewidth(2)
+                    patch.set_linewidth(3)
+                    patch.set_zorder(20)
                 else:
                     patch.set_edgecolor("black")
                     patch.set_linewidth(1)
+                    patch.set_zorder(1)
         self.canvas.draw_idle()
 
     def sort_layers(self):
@@ -2179,7 +2212,12 @@ class TabPallet(ttk.Frame):
             return
         if TabPallet._toolbar_busy(self):
             return
-        result = self.editor_controller.on_motion(event.xdata, event.ydata)
+        result = self.editor_controller.on_motion(
+            event.xdata,
+            event.ydata,
+            getattr(event, "x", None),
+            getattr(event, "y", None),
+        )
         if not result or not self.editor_controller.is_dragging:
             return
         active_layer = self.editor_controller.active_layer
@@ -2215,12 +2253,14 @@ class TabPallet(ttk.Frame):
                     pallet_w,
                     pallet_l,
                 )[0]
+                orig_x = TabPallet._round_mm(orig_x)
+                orig_y = TabPallet._round_mm(orig_y)
                 delta_logical = (orig_x - x, orig_y - y)
                 self.layers[layer_idx][idx] = (orig_x, orig_y, w, h)
                 layers_to_check.add(layer_idx)
 
                 allowed_layers = _matching_layers_for_pattern(self, layer_idx)
-                if not self.edit_layers_linked():
+                if not TabPallet._safe_edit_layers_linked(self):
                     allowed_layers = [
                         i for i in allowed_layers if i % 2 == layer_idx % 2
                     ]
@@ -2297,11 +2337,13 @@ class TabPallet(ttk.Frame):
                 snap_x, snap_y = self.snap_position(
                     orig_x, orig_y, w, h, pallet_w, pallet_l, other_boxes
                 )
+                snap_x = TabPallet._round_mm(snap_x)
+                snap_y = TabPallet._round_mm(snap_y)
                 delta_logical = (snap_x - x, snap_y - y)
                 self.layers[layer_idx][idx] = (snap_x, snap_y, w, h)
 
                 allowed_layers = _matching_layers_for_pattern(self, layer_idx)
-                if not self.edit_layers_linked():
+                if not TabPallet._safe_edit_layers_linked(self):
                     allowed_layers = [
                         i for i in allowed_layers if i % 2 == layer_idx % 2
                     ]
@@ -2314,7 +2356,6 @@ class TabPallet(ttk.Frame):
                     allowed_layers=allowed_layers,
                     reference_box=(x, y, w, h),
                 )
-            getattr(self, "sort_layers", lambda: None)()
             self.draw_pallet()
             self.update_summary()
             self.highlight_selection()
@@ -2356,11 +2397,13 @@ class TabPallet(ttk.Frame):
             snap_x, snap_y = self.snap_position(
                 orig_x, orig_y, w, h, pallet_w, pallet_l, other_boxes
             )
+            snap_x = TabPallet._round_mm(snap_x)
+            snap_y = TabPallet._round_mm(snap_y)
             delta_logical = (snap_x - x, snap_y - y)
             self.layers[layer_idx][idx] = (snap_x, snap_y, w, h)
 
             allowed_layers = _matching_layers_for_pattern(self, layer_idx)
-            if not self.edit_layers_linked():
+            if not TabPallet._safe_edit_layers_linked(self):
                 allowed_layers = [
                     i for i in allowed_layers if i % 2 == layer_idx % 2
                 ]
@@ -2375,7 +2418,6 @@ class TabPallet(ttk.Frame):
             )
 
         self.drag_snapshot_saved = False
-        getattr(self, "sort_layers", lambda: None)()
         self.draw_pallet()
         self.update_summary()
         self.highlight_selection()
@@ -2393,7 +2435,7 @@ class TabPallet(ttk.Frame):
         self.layers[layer_idx].append((pos[0], pos[1], w, h))
         next_id = max(self.carton_ids[layer_idx], default=0) + 1
         self.carton_ids[layer_idx].append(next_id)
-        for target_layer in self._edit_target_layers(layer_idx, include_source=False):
+        for target_layer in TabPallet._safe_edit_target_layers(self, layer_idx, include_source=False):
             if target_layer >= len(self.layers):
                 continue
             self.layers[target_layer].append((pos[0], pos[1], w, h))
@@ -2401,7 +2443,7 @@ class TabPallet(ttk.Frame):
             self.carton_ids[target_layer].append(next_id_other)
         getattr(self, "sort_layers", lambda: None)()
         self.renumber_layer(layer_idx)
-        for target_layer in self._edit_target_layers(layer_idx, include_source=False):
+        for target_layer in TabPallet._safe_edit_target_layers(self, layer_idx, include_source=False):
             if target_layer < len(self.layers):
                 self.renumber_layer(target_layer)
         self.draw_pallet()
@@ -2421,7 +2463,7 @@ class TabPallet(ttk.Frame):
         affected = set()
         source_layer = next(iter(selection))[0]
         indices = sorted({idx for layer, idx in selection if layer == source_layer}, reverse=True)
-        target_layers = self._edit_target_layers(source_layer, include_source=True)
+        target_layers = TabPallet._safe_edit_target_layers(self, source_layer, include_source=True)
         for layer_idx in target_layers:
             if layer_idx >= len(self.layers):
                 continue
@@ -2452,7 +2494,7 @@ class TabPallet(ttk.Frame):
         TabPallet._record_state(self)
         source_layer = next(iter(selection))[0]
         indices = [idx for layer, idx in selection if layer == source_layer]
-        target_layers = self._edit_target_layers(source_layer, include_source=True)
+        target_layers = TabPallet._safe_edit_target_layers(self, source_layer, include_source=True)
         for idx in indices:
             if source_layer >= len(self.layers) or idx >= len(self.layers[source_layer]):
                 continue
@@ -2531,13 +2573,13 @@ class TabPallet(ttk.Frame):
         for i, size in zip(sorted(indices), sizes):
             x, y, w, h = boxes[i]
             if orientation == "x":
-                x = pos
+                x = TabPallet._round_mm(pos)
                 pos += size + gap
             else:
-                y = pos
+                y = TabPallet._round_mm(pos)
                 pos += size + gap
             boxes[i] = (x, y, w, h)
-        for target_layer in self._edit_target_layers(layer_idx, include_source=False):
+        for target_layer in TabPallet._safe_edit_target_layers(self, layer_idx, include_source=False):
             if target_layer >= len(self.layers):
                 continue
             for i in indices:
@@ -2760,7 +2802,7 @@ class TabPallet(ttk.Frame):
             x, y, w, h = boxes[i]
             boxes[i] = (x + offset_x, y + offset_y, w, h)
 
-        for target_layer in self._edit_target_layers(layer_idx, include_source=False):
+        for target_layer in TabPallet._safe_edit_target_layers(self, layer_idx, include_source=False):
             if target_layer >= len(self.layers):
                 continue
             for i in indices:

--- a/tests/test_gui_sync.py
+++ b/tests/test_gui_sync.py
@@ -150,7 +150,7 @@ def test_distribution_commands():
     dummy._set_selection_pairs({(0, 0), (0, 1), (0, 2)})
     TabPallet.distribute_selected_edges(dummy)
     xs = [pos[0] for pos in dummy.layers[0]]
-    assert xs == pytest.approx([17.5,45.0,72.5])
+    assert xs == [18, 45, 73]
 
     dummy = make_dummy()
     dummy.layers = [[(0,0,10,10),(10,0,10,10),(40,0,10,10),(80,0,10,10)], [(0,0,10,10),(10,0,10,10),(40,0,10,10),(80,0,10,10)]]
@@ -158,7 +158,7 @@ def test_distribution_commands():
     dummy._set_selection_pairs({(0, 1), (0, 2)})
     TabPallet.distribute_selected_between(dummy)
     xs = [dummy.layers[0][1][0], dummy.layers[0][2][0]]
-    assert xs == pytest.approx([26.6666666667,53.3333333333])
+    assert xs == [27, 53]
 
 def test_auto_distribution_respects_boundaries():
     dummy = make_dummy()

--- a/tests/test_tab_2d_display_helpers.py
+++ b/tests/test_tab_2d_display_helpers.py
@@ -1,0 +1,27 @@
+import types
+
+from packing_app.gui.tab_2d import TabPacking2D
+
+
+def test_display_grid_preserves_sparse_row_counts():
+    dummy = types.SimpleNamespace()
+    dummy._group_rows = TabPacking2D._group_rows.__get__(dummy)
+    centers = [(5, 5), (15, 5), (5, 15)]
+
+    new_centers, gap_x, gap_y, rows, cols = TabPacking2D._apply_display_grid(
+        dummy, 30, 30, 5, centers, gap_x=2, gap_y=2
+    )
+
+    assert rows == 2
+    assert cols == 2
+    assert len(new_centers) == len(centers)
+    assert gap_x == 2
+    assert gap_y == 2
+
+
+def test_centers_within_bounds_detects_manual_display_overflow():
+    inside = [(5, 5), (15, 5)]
+    outside = [(5, 5), (28, 5)]
+
+    assert TabPacking2D._centers_within_bounds(None, 30, 30, 10, inside)
+    assert not TabPacking2D._centers_within_bounds(None, 30, 30, 10, outside)


### PR DESCRIPTION
### Motivation
- Improve mouse-drag detection robustness by supporting screen pixel delta to avoid accidental drags from coordinate transforms and to keep logical moves in whole millimeters.  
- Expose and validate air-cushion dimensions and make display spacing calculations safer so manual spacing cannot push items outside the carton.  
- Harden layer-edit propagation logic and rendering so edits across linked layers behave predictably and visuals are clearer.

### Description
- Updated `EditorController.on_motion` to accept optional `screen_x`/`screen_y` and use a separate `_screen_drag_start` for pixel-based drag threshold checks, and clear the helper attribute on release/reset.  
- Extended `TabPacking2D` UI: introduced a localized `manual_carton_label`, added air-cushion dimension inputs (`cushion_w`, `cushion_l`, `cushion_h`), wired traces, passed explicit cushion sizes into `place_air_cushions`, and improved related warnings.  
- Fixed display grid logic in `_apply_display_grid` to preserve sparse row counts, added `_centers_within_bounds` to detect manual display overflow, and changed formatting/rounding of carton/gap values to integer mm in several places.  
- Several label/localization tweaks and improved area text (showing cm²) in `TabPacking2D`.  
- In `TabPallet` added safe wrappers for layer-edit checks, introduced `_round_mm` to snap logical coordinates to integer mm when moving/snapping/distributing cartons, increased highlight linewidth and z-order for selected patches, validated pallet dimensions before drawing, and adjusted undo clearing logic.  
- Replaced direct calls to edit-target helpers with safe variants to avoid calling into overridden methods unsafely.  
- Updated unit tests: adjusted expectations in `tests/test_gui_sync.py` to reflect integer rounding and added `tests/test_tab_2d_display_helpers.py` to cover grid/display helper behavior.

### Testing
- Ran the unit tests including `tests/test_gui_sync.py` and the new `tests/test_tab_2d_display_helpers.py` under `pytest`; all tests completed successfully.  
- Exercised interactive flows for dragging, snapping and air-cushion toggles via the existing GUI tests to ensure no regressions in selection propagation and rendering.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38f92f9cec83259335aa72169bc77d)